### PR TITLE
update for issue 1-3

### DIFF
--- a/master/master_3_contoller_manager.sh
+++ b/master/master_3_contoller_manager.sh
@@ -23,7 +23,7 @@ else
 fi
 
 check_1_3_4="1.3.4  - Ensure that the --use-service-account-credentials argument is set to true"
-if check_argument 'kube-controller-manager' '--use-service-account-credentials=true' >/dev/null 2>&1; then
+if check_argument 'kube-controller-manager' '--use-service-account-credentials' >/dev/null 2>&1; then
     pass "$check_1_3_4"
 else
     warn "$check_1_3_4"

--- a/master/master_4_configuration_files.sh
+++ b/master/master_4_configuration_files.sh
@@ -2,7 +2,7 @@
 check_1_4_1="1.4.1  - Ensure that the apiserver file permissions are set to 644 or more restrictive"
 file="/etc/kubernetes/manifests/kube-apiserver.json"
 if [ -f "$file" ]; then
-  if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 ]; then
+  if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 640 -o "$(stat -c %a $file)" -eq 600 ]; then
     pass "$check_1_4_1"
   else
     warn "$check_1_4_1"
@@ -29,7 +29,7 @@ fi
 check_1_4_3="1.4.3  - Ensure that the config file permissions are set to 644 or more restrictive"
 file="/etc/kubernetes/admin.conf"
 if [ -f "$file" ]; then
-  if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 ]; then
+  if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 640 -o "$(stat -c %a $file)" -eq 600 ]; then
     pass "$check_1_4_3"
   else
     warn "$check_1_4_3"
@@ -57,7 +57,7 @@ fi
 check_1_4_5="1.4.5  - Ensure that the scheduler file permissions are set to 644 or more restrictive"
 file="/etc/kubernetes/manifests/kube-scheduler.json"
 if [ -f "$file" ]; then
-  if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 ]; then
+  if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 640 -o "$(stat -c %a $file)" -eq 600 ]; then
     pass "$check_1_4_5"
   else
     warn "$check_1_4_5"
@@ -85,7 +85,7 @@ fi
 check_1_4_7="1.4.7  - Ensure that the etcd.conf file permissions are set to 644 or more restrictive"
 file="/etc/kubernetes/manifests/etcd.json"
 if [ -f "$file" ]; then
-  if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 ]; then
+  if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 640 -o "$(stat -c %a $file)" -eq 600 ]; then
     pass "$check_1_4_7"
   else
     warn "$check_1_4_7"

--- a/master/master_5_etcd.sh
+++ b/master/master_5_etcd.sh
@@ -15,7 +15,7 @@ else
 fi
 
 check_1_5_2="1.5.2  - Ensure that the --client-cert-auth argument is set to true (Scored)"
-if check_argument 'etcd' '--client-cert-auth=true' >/dev/null 2>&1; then
+if check_argument 'etcd' '--client-cert-auth' >/dev/null 2>&1; then
     pass "$check_1_5_2"
 else
     warn "$check_1_5_2"
@@ -44,7 +44,7 @@ else
 fi
 
 check_1_5_5="1.5.5  - Ensure that the --peer-client-cert-auth argument is set to true (Scored)"
-if check_argument 'etcd' '--peer-client-cert-auth=true' >/dev/null 2>&1; then
+if check_argument 'etcd' '--peer-client-cert-auth' >/dev/null 2>&1; then
     pass "$check_1_5_5"
 else
     warn "$check_1_5_5"

--- a/master/master_5_etcd.sh
+++ b/master/master_5_etcd.sh
@@ -1,7 +1,7 @@
 
 check_1_5_1="1.5.1  - Ensure that the --cert-file and --key-file arguments are set as appropriate (Scored)"
-if check_argument 'etcd' '--cert-file' >/dev/null 2>&1; then
-	if check_argument 'etcd' '--key-file' >/dev/null 2>&1; then
+if check_argument 'etcd' '-cert-file' >/dev/null 2>&1; then
+	if check_argument 'etcd' '-key-file' >/dev/null 2>&1; then
 		cfile=$(get_argument_value 'etcd' '--cert-file')
 		kfile=$(get_argument_value 'etcd' '--key-file')
 	  	pass "$check_1_5_1"
@@ -15,22 +15,22 @@ else
 fi
 
 check_1_5_2="1.5.2  - Ensure that the --client-cert-auth argument is set to true (Scored)"
-if check_argument 'etcd' '--client-cert-auth' >/dev/null 2>&1; then
+if check_argument 'etcd' '-client-cert-auth' >/dev/null 2>&1; then
     pass "$check_1_5_2"
 else
     warn "$check_1_5_2"
 fi
 
 check_1_5_3="1.5.3  - Ensure that the --auto-tls argument is not set to true (Scored)"
-if check_argument 'etcd' '--auto-tls=tru' >/dev/null 2>&1; then
+if check_argument 'etcd' '-auto-tls=tru' >/dev/null 2>&1; then
     warn "$check_1_5_3"
 else
     pass "$check_1_5_3"
 fi
 
 check_1_5_4="1.5.4  - Ensure that the --peer-cert-file and --peer-key-file arguments are set as appropriate (Scored)"
-if check_argument 'etcd' '--peer-cert-file' >/dev/null 2>&1; then
-	if check_argument 'etcd' '--peer-key-file' >/dev/null 2>&1; then
+if check_argument 'etcd' '-peer-cert-file' >/dev/null 2>&1; then
+	if check_argument 'etcd' '-peer-key-file' >/dev/null 2>&1; then
 		cfile=$(get_argument_value 'etcd' '--peer-cert-file')
 		kfile=$(get_argument_value 'etcd' '--peer-key-file')
 	  	pass "$check_1_5_4"
@@ -44,21 +44,21 @@ else
 fi
 
 check_1_5_5="1.5.5  - Ensure that the --peer-client-cert-auth argument is set to true (Scored)"
-if check_argument 'etcd' '--peer-client-cert-auth' >/dev/null 2>&1; then
+if check_argument 'etcd' '-peer-client-cert-auth' >/dev/null 2>&1; then
     pass "$check_1_5_5"
 else
     warn "$check_1_5_5"
 fi
 
 check_1_5_6="1.5.6  - Ensure that the --peer-auto-tls argument is not set to true (Scored)"
-if check_argument 'etcd' '--peer-auto-tls=true' >/dev/null 2>&1; then
+if check_argument 'etcd' '-peer-auto-tls=true' >/dev/null 2>&1; then
     warn "$check_1_5_6"
 else
     pass "$check_1_5_6"
 fi
 
 check_1_5_7="1.5.7  - Ensure that the --wal-dir argument is set as appropriate (Scored)"
-if check_argument 'etcd' '--wal-dir' >/dev/null 2>&1; then
+if check_argument 'etcd' '-wal-dir' >/dev/null 2>&1; then
 	wdir=$(get_argument_value 'etcd' '--wal-dir')
     pass "$check_1_5_7"
     pass "       * wal-dir: $wdir"
@@ -67,7 +67,7 @@ else
 fi
 
 check_1_5_8="1.5.8  - Ensure that the --max-wals argument is set to 0 (Scored)"
-if check_argument 'etcd' '--max-wals=0' >/dev/null 2>&1; then
+if check_argument 'etcd' '-max-wals=0' >/dev/null 2>&1; then
     pass "$check_1_5_8"
 else
     warn "$check_1_5_8"

--- a/worker/worker_1_kubelet.sh
+++ b/worker/worker_1_kubelet.sh
@@ -1,6 +1,6 @@
 
 check_2_1_1="2.1.1  - Ensure that the --allow-privileged argument is set to false"
-if check_argument 'kubelet-real' '--allow-privileged' >/dev/null 2>&1; then
+if check_argument 'kubelet-real' '--allow-privileged=false' >/dev/null 2>&1; then
     pass "$check_2_1_1"
 else
     warn "$check_2_1_1"


### PR DESCRIPTION
issue 4: we follow the spec:
By default, if no --service-account-key-file is specified to the apiserver, it uses the private key from the TLS serving certificate to verify service account tokens. To ensure that the keys for service account tokens could be rotated as needed, a separate public/private key pair should be used for signing service account tokens. Hence, the public key should be specified to the apiserver with --service-account-key-file.

issue 5: the spec is "--" , but maybe "-" also work. 