### PR TITLE
kops support (and some other fixes)

### DIFF
--- a/1.8/master/master_3_contoller_manager.sh
+++ b/1.8/master/master_3_contoller_manager.sh
@@ -1,31 +1,41 @@
 info "1.3 - Controller Manager"
 
 check_1_3_1="1.3.1  - Ensure that the --terminated-pod-gc-threshold argument is set as appropriate"
-if check_argument 'kube-controller-manager' '--terminated-pod-gc-threshold' >/dev/null 2>&1; then
-    threshold=$(get_argument_value 'kube-controller-manager' '--terminated-pod-gc-threshold')
+# On a kops-managed cluster, kube-controller-manager is run like this:
+#
+# \_ /bin/sh -c /usr/local/bin/kube-controller-manager | /bin/tee -a /var/log/kube-controller-manager.log
+#     \_ /usr/local/bin/kube-controller-manager
+#     \_ /bin/tee -a /var/log/kube-controller-manager.log
+#
+# This causes `check_argument 'kube-controller-manager'` to discover the
+# logging command rather than the actual service. Adding 'bin/' to the expected
+# command works around this.
+if check_argument 'bin/kube-controller-manager' '--terminated-pod-gc-threshold' >/dev/null 2>&1; then
+    threshold=$(get_argument_value 'bin/kube-controller-manager' '--terminated-pod-gc-threshold')
     pass "$check_1_3_1"
     pass "       * terminated-pod-gc-threshold: $threshold"
 else
+    echo "done"
     warn "$check_1_3_1"
 fi
 
 check_1_3_2="1.3.2  - Ensure that the --profiling argument is set to false"
-if check_argument 'kube-controller-manager' '--profiling=false' >/dev/null 2>&1; then
+if check_argument 'bin/kube-controller-manager' '--profiling=false' >/dev/null 2>&1; then
     pass "$check_1_3_2"
 else
     warn "$check_1_3_2"
 fi
 
 check_1_3_3="1.3.3  - Ensure that the --use-service-account-credentials argument is set to true"
-if check_argument 'kube-controller-manager' '--use-service-account-credentials' >/dev/null 2>&1; then
+if check_argument 'bin/kube-controller-manager' '--use-service-account-credentials' >/dev/null 2>&1; then
     pass "$check_1_3_3"
 else
     warn "$check_1_3_3"
 fi
 
 check_1_3_4="1.3.4  - Ensure that the --service-account-private-key-file argument is set as appropriate"
-if check_argument 'kube-controller-manager' '--service-account-private-key-file' >/dev/null 2>&1; then
-    keyfile=$(get_argument_value 'kube-controller-manager' '--service-account-private-key-file')
+if check_argument 'bin/kube-controller-manager' '--service-account-private-key-file' >/dev/null 2>&1; then
+    keyfile=$(get_argument_value 'bin/kube-controller-manager' '--service-account-private-key-file')
     pass "$check_1_3_4"
     pass "       * service-account-private-key-file: $keyfile"
 else
@@ -33,8 +43,8 @@ else
 fi
 
 check_1_3_5="1.3.5  - Ensure that the --root-ca-file argument is set as appropriate"
-if check_argument 'kube-controller-manager' '--root-ca-file' >/dev/null 2>&1; then
-    cafile=$(get_argument_value 'kube-controller-manager' '--root-ca-file')
+if check_argument 'bin/kube-controller-manager' '--root-ca-file' >/dev/null 2>&1; then
+    cafile=$(get_argument_value 'bin/kube-controller-manager' '--root-ca-file')
     pass "$check_1_3_5"
     pass "       * root-ca-file: $cafile"
 else

--- a/1.8/master/master_3_contoller_manager.sh
+++ b/1.8/master/master_3_contoller_manager.sh
@@ -16,34 +16,27 @@ else
     warn "$check_1_3_2"
 fi
 
-check_1_3_3="1.3.3  - Ensure that the --insecure-experimental-approve-all-kubelet-csrs-for-group argument is not set"
-if check_argument 'kube-controller-manager' '--insecure-experimental-approve-all-kubelet-csrs-for-group' >/dev/null 2>&1; then
-    warn "$check_1_3_3"
-else
+check_1_3_3="1.3.3  - Ensure that the --use-service-account-credentials argument is set to true"
+if check_argument 'kube-controller-manager' '--use-service-account-credentials' >/dev/null 2>&1; then
     pass "$check_1_3_3"
+else
+    warn "$check_1_3_3"
 fi
 
-check_1_3_4="1.3.4  - Ensure that the --use-service-account-credentials argument is set to true"
-if check_argument 'kube-controller-manager' '--use-service-account-credentials' >/dev/null 2>&1; then
+check_1_3_4="1.3.4  - Ensure that the --service-account-private-key-file argument is set as appropriate"
+if check_argument 'kube-controller-manager' '--service-account-private-key-file' >/dev/null 2>&1; then
+    keyfile=$(get_argument_value 'kube-controller-manager' '--service-account-private-key-file')
     pass "$check_1_3_4"
+    pass "       * service-account-private-key-file: $keyfile"
 else
     warn "$check_1_3_4"
 fi
 
-check_1_3_5="1.3.5  - Ensure that the --service-account-private-key-file argument is set as appropriate"
-if check_argument 'kube-controller-manager' '--service-account-private-key-file' >/dev/null 2>&1; then
-    keyfile=$(get_argument_value 'kube-controller-manager' '--service-account-private-key-file')
-    pass "$check_1_3_5"
-    pass "       * service-account-private-key-file: $keyfile"
-else
-    warn "$check_1_3_5"
-fi
-
-check_1_3_6="1.3.6  - Ensure that the --root-ca-file argument is set as appropriate"
+check_1_3_5="1.3.5  - Ensure that the --root-ca-file argument is set as appropriate"
 if check_argument 'kube-controller-manager' '--root-ca-file' >/dev/null 2>&1; then
     cafile=$(get_argument_value 'kube-controller-manager' '--root-ca-file')
-    pass "$check_1_3_6"
+    pass "$check_1_3_5"
     pass "       * root-ca-file: $cafile"
 else
-    warn "$check_1_3_6"
+    warn "$check_1_3_5"
 fi

--- a/1.8/master/master_3_contoller_manager.sh
+++ b/1.8/master/master_3_contoller_manager.sh
@@ -1,17 +1,10 @@
 info "1.3 - Controller Manager"
 
 check_1_3_1="1.3.1  - Ensure that the --terminated-pod-gc-threshold argument is set as appropriate"
-# On a kops-managed cluster, kube-controller-manager is run like this:
-#
-# \_ /bin/sh -c /usr/local/bin/kube-controller-manager | /bin/tee -a /var/log/kube-controller-manager.log
-#     \_ /usr/local/bin/kube-controller-manager
-#     \_ /bin/tee -a /var/log/kube-controller-manager.log
-#
-# This causes `check_argument 'kube-controller-manager'` to discover the
-# logging command rather than the actual service. Adding 'bin/' to the expected
-# command works around this.
-if check_argument 'bin/kube-controller-manager' '--terminated-pod-gc-threshold' >/dev/null 2>&1; then
-    threshold=$(get_argument_value 'bin/kube-controller-manager' '--terminated-pod-gc-threshold')
+# Filter out processes like "/bin/tee -a /var/log/kube-controller-manager.log"
+# which exist on kops-managed clusters.
+if check_argument 'kube-controller-manager(\s|$)' '--terminated-pod-gc-threshold' >/dev/null 2>&1; then
+    threshold=$(get_argument_value 'kube-controller-manager(\s|$)' '--terminated-pod-gc-threshold')
     pass "$check_1_3_1"
     pass "       * terminated-pod-gc-threshold: $threshold"
 else
@@ -20,22 +13,22 @@ else
 fi
 
 check_1_3_2="1.3.2  - Ensure that the --profiling argument is set to false"
-if check_argument 'bin/kube-controller-manager' '--profiling=false' >/dev/null 2>&1; then
+if check_argument 'kube-controller-manager(\s|$)' '--profiling=false' >/dev/null 2>&1; then
     pass "$check_1_3_2"
 else
     warn "$check_1_3_2"
 fi
 
 check_1_3_3="1.3.3  - Ensure that the --use-service-account-credentials argument is set to true"
-if check_argument 'bin/kube-controller-manager' '--use-service-account-credentials' >/dev/null 2>&1; then
+if check_argument 'kube-controller-manager(\s|$)' '--use-service-account-credentials' >/dev/null 2>&1; then
     pass "$check_1_3_3"
 else
     warn "$check_1_3_3"
 fi
 
 check_1_3_4="1.3.4  - Ensure that the --service-account-private-key-file argument is set as appropriate"
-if check_argument 'bin/kube-controller-manager' '--service-account-private-key-file' >/dev/null 2>&1; then
-    keyfile=$(get_argument_value 'bin/kube-controller-manager' '--service-account-private-key-file')
+if check_argument 'kube-controller-manager(\s|$)' '--service-account-private-key-file' >/dev/null 2>&1; then
+    keyfile=$(get_argument_value 'kube-controller-manager(\s|$)' '--service-account-private-key-file')
     pass "$check_1_3_4"
     pass "       * service-account-private-key-file: $keyfile"
 else
@@ -43,8 +36,8 @@ else
 fi
 
 check_1_3_5="1.3.5  - Ensure that the --root-ca-file argument is set as appropriate"
-if check_argument 'bin/kube-controller-manager' '--root-ca-file' >/dev/null 2>&1; then
-    cafile=$(get_argument_value 'bin/kube-controller-manager' '--root-ca-file')
+if check_argument 'kube-controller-manager(\s|$)' '--root-ca-file' >/dev/null 2>&1; then
+    cafile=$(get_argument_value 'kube-controller-manager(\s|$)' '--root-ca-file')
     pass "$check_1_3_5"
     pass "       * root-ca-file: $cafile"
 else

--- a/1.8/master/master_4_configuration_files.sh
+++ b/1.8/master/master_4_configuration_files.sh
@@ -174,7 +174,7 @@ check_1_4_9="1.4.9  - Ensure that the Container Network Interface file permissio
 check_1_4_10="1.4.10  - Ensure that the Container Network Interface file ownership is set to root:root"
 check_1_4_11="1.4.11  - Ensure that the etcd data directory permissions are set to 700 or more restrictive"
 directory=$(get_argument_value 'etcd' '--data-dir')
-if [ -d $directory ]; then
+if [ -d "$directory" ]; then
   if [ "$(stat -c %a $directory)" -eq 700 ]; then
     pass "$check_1_4_11"
   else
@@ -189,7 +189,7 @@ fi
 
 check_1_4_12="1.4.12  - Ensure that the etcd data directory ownership is set to etcd:etcd"
 directory=$(get_argument_value 'etcd' '--data-dir')
-if [ -d $directory ]; then
+if [ -d "$directory" ]; then
   if [ "$(stat -c %U:%G $directory)" = "etcd:etcd" ]; then
     pass "$check_1_4_12"
   else

--- a/1.8/master/master_4_configuration_files.sh
+++ b/1.8/master/master_4_configuration_files.sh
@@ -3,6 +3,9 @@ info "1.4 - Configuration Files"
 check_1_4_1="1.4.1  - Ensure that the API server pod specification file permissions are set to 644 or more restrictive"
 if [ -f "/etc/kubernetes/manifests/kube-apiserver.json" ]; then
     file="/etc/kubernetes/manifests/kube-apiserver.json"
+elif [ -f "/etc/kubernetes/manifests/kube-apiserver.manifest" ]; then
+    # kops
+    file="/etc/kubernetes/manifests/kube-apiserver.manifest"
 else
     file="/etc/kubernetes/manifests/kube-apiserver.yaml"
 fi
@@ -21,6 +24,9 @@ fi
 check_1_4_2="1.4.2  - Ensure that the API server pod specification file ownership is set to root:root"
 if [ -f "/etc/kubernetes/manifests/kube-apiserver.json" ]; then
     file="/etc/kubernetes/manifests/kube-apiserver.json"
+elif [ -f "/etc/kubernetes/manifests/kube-apiserver.manifest" ]; then
+    # kops
+    file="/etc/kubernetes/manifests/kube-apiserver.manifest"
 else
     file="/etc/kubernetes/manifests/kube-apiserver.yaml"
 fi
@@ -37,7 +43,10 @@ fi
 
 check_1_4_3="1.4.3  - Ensure that the controller manager pod specification file permissions are set to 644 or more restrictive"
 if [ -f "/etc/kubernetes/manifests/kube-controller-manager.json" ]; then
-	file="/etc/kubernetes/manifests/kube-controller-manager.json"
+    file="/etc/kubernetes/manifests/kube-controller-manager.json"
+elif [ -f "/etc/kubernetes/manifests/kube-controller-manager.manifest" ]; then
+    # kops
+    file="/etc/kubernetes/manifests/kube-controller-manager.manifest"
 else
     file="/etc/kubernetes/manifests/kube-controller-manager.yaml"
 fi
@@ -55,7 +64,10 @@ fi
 
 check_1_4_4="1.4.4  - Ensure that the controller manager pod specification file ownership is set to root:root"
 if [ -f "/etc/kubernetes/manifests/kube-controller-manager.json" ]; then
-	file="/etc/kubernetes/manifests/kube-controller-manager.json"
+    file="/etc/kubernetes/manifests/kube-controller-manager.json"
+elif [ -f "/etc/kubernetes/manifests/kube-controller-manager.manifest" ]; then
+    # kops
+    file="/etc/kubernetes/manifests/kube-controller-manager.manifest"
 else
     file="/etc/kubernetes/manifests/kube-controller-manager.yaml"
 fi
@@ -74,6 +86,9 @@ fi
 check_1_4_5="1.4.5  - Ensure that the scheduler pod specification file permissions are set to 644 or more restrictive"
 if [ -f "/etc/kubernetes/manifests/kube-scheduler.json" ]; then
     file="/etc/kubernetes/manifests/kube-scheduler.json"
+elif [ -f "/etc/kubernetes/manifests/kube-scheduler.manifest" ]; then
+    # kops
+    file="/etc/kubernetes/manifests/kube-scheduler.manifest"
 else
     file="/etc/kubernetes/manifests/kube-scheduler.yaml"
 fi
@@ -92,6 +107,9 @@ fi
 check_1_4_6="1.4.6  - Ensure that the scheduler pod specification file ownership is set to root:root"
 if [ -f "/etc/kubernetes/manifests/kube-scheduler.json" ]; then
     file="/etc/kubernetes/manifests/kube-scheduler.json"
+elif [ -f "/etc/kubernetes/manifests/kube-scheduler.manifest" ]; then
+    # kops
+    file="/etc/kubernetes/manifests/kube-scheduler.manifest"
 else
     file="/etc/kubernetes/manifests/kube-scheduler.yaml"
 fi
@@ -111,11 +129,15 @@ fi
 check_1_4_7="1.4.7  - Ensure that the etcd pod specification file permissions are set to 644 or more restrictive"
 if [ -f "/etc/kubernetes/manifests/etcd.json" ]; then
     file="/etc/kubernetes/manifests/etcd.json"
+elif [ -f "/etc/kubernetes/manifests/etcd.manifest" ]; then
+    # kops
+    # Also this file is a symlink, hence 'stat -L' below.
+    file="/etc/kubernetes/manifests/etcd.manifest"
 else
     file="/etc/kubernetes/manifests/etcd.yaml"
 fi
 if [ -f $file ]; then
-  if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 640 -o "$(stat -c %a $file)" -eq 600 ]; then
+  if [ "$(stat -L -c %a $file)" -eq 644 -o "$(stat -L -c %a $file)" -eq 640 -o "$(stat -L -c %a $file)" -eq 600 ]; then
     pass "$check_1_4_7"
   else
     warn "$check_1_4_7"
@@ -129,6 +151,9 @@ fi
 check_1_4_8="1.4.8  - Ensure that the etcd pod specification file ownership is set to root:root"
 if [ -f "/etc/kubernetes/manifests/etcd.json" ]; then
     file="/etc/kubernetes/manifests/etcd.json"
+elif [ -f "/etc/kubernetes/manifests/etcd.manifest" ]; then
+    # kops
+    file="/etc/kubernetes/manifests/etcd.manifest"
 else
     file="/etc/kubernetes/manifests/etcd.yaml"
 fi

--- a/1.8/worker/worker_2_configure_files.sh
+++ b/1.8/worker/worker_2_configure_files.sh
@@ -3,12 +3,15 @@ info "2.2 - Configuration Files"
 check_2_2_1="2.2.1  - Ensure that the config file permissions are set to 644 or more restrictive"
 if [ -f "/etc/kubernetes/config" ]; then
     file="/etc/kubernetes/config"
+elif [ -f "/var/lib/kubelet/kubeconfig" ]; then
+    # kops
+    file="/var/lib/kubelet/kubeconfig"
 else
     file="/etc/kubernetes/kubelet.conf"
 fi
 
 if [ -f "$file" ]; then
-  if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 ]; then
+  if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_2_2_1"
   else
     warn "$check_2_2_1"
@@ -34,12 +37,15 @@ fi
 check_2_2_3="2.2.3  - Ensure that the kubelet file permissions are set to 644 or more restrictive"
 if [ -f "/etc/kubernetes/kubelet" ]; then
     file="/etc/kubernetes/kubelet"
+elif [ -f "/etc/sysconfig/kubelet" ]; then
+    # kops
+    file="/etc/sysconfig/kubelet"
 else
     file="/etc/kubernetes/kubelet.conf"
 fi
 
 if [ -f "$file" ]; then
-  if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 ]; then
+  if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_2_2_3"
   else
     warn "$check_2_2_3"
@@ -63,10 +69,15 @@ else
 fi
 
 check_2_2_5="2.2.5  - Ensure that the proxy file permissions are set to 644 or more restrictive"
-file="/etc/kubernetes/proxy"
+if [ -f "/var/lib/kube-proxy/kubeconfig" ]; then
+    # kops
+    file="/var/lib/kube-proxy/kubeconfig"
+else
+    file="/etc/kubernetes/proxy"
+fi
 
 if [ -f "$file" ]; then
-  if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 ]; then
+  if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_2_2_5"
   else
     warn "$check_2_2_5"

--- a/1.8/worker/worker_2_configure_files.sh
+++ b/1.8/worker/worker_2_configure_files.sh
@@ -100,4 +100,32 @@ else
   info "$check_2_2_6"
 fi
 
+check_2_2_7="2.2.7  - Ensure that the certificate authorities file permissions are set to 644 or more restrictive"
+if check_argument 'kubelet' '--client-ca-file' >/dev/null 2>&1; then
+  file=$(get_argument_value 'kubelet' '--client-ca-file')
+  if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
+    pass "$check_2_2_7"
+    pass "       * client-ca-file: $file"
+  else
+    warn "$check_2_2_7"
+    warn "     * Wrong permissions for $file"
+  fi
+else
+  info "$check_2_2_7"
+  info "     * --client-ca-file not set"
+fi
 
+check_2_2_8="2.2.8  - Ensure that the client certificate authorities file ownership is set to root:root"
+if check_argument 'kubelet' '--client-ca-file' >/dev/null 2>&1; then
+  file=$(get_argument_value 'kubelet' '--client-ca-file')
+  if [ "$(stat -c %u%g $file)" -eq 00 ]; then
+    pass "$check_2_2_8"
+    pass "       * client-ca-file: $file"
+  else
+    warn "$check_2_2_8"
+    warn "     * Wrong ownership for $file"
+  fi
+else
+  info "$check_2_2_8"
+  info "     * --client-ca-file not set"
+fi


### PR DESCRIPTION
I found this project while looking at the CIS Kubernetes Benchmark. Thanks for sharing it!

This PR adds partial support for Kubernetes clusters created with [kops](https://github.com/kubernetes/kops/). It also adds Benchmark items 2.2.7-2.2.8, and deletes obsolete 1.3.3 (and renumbers subsequent items). However, I did this work as a proof of concept so I didn't update all the checks (e.g. the checks for etcd, which kops runs in a container and without using command-line flags).

I don't have a kubeadm-managed cluster handy, so I couldn't verify that my slightly-ugly kube-controller-manager hack for 1.3 (see comment) works there.

Hopefully these changes are useful to others and acceptable to "mainstream" to the upstream project. :)