### PR TITLE
Refactor benchmark check scripts version 1.6.0

### DIFF
--- a/1.6.0-refactor/master/1_control_plane_components.sh
+++ b/1.6.0-refactor/master/1_control_plane_components.sh
@@ -1,0 +1,74 @@
+info "1 - Control Plane Components"
+
+info "1.1 - Master Node Configuration Files"
+check_number="1.1.1" . ./checks/control_plane_components/configuration_files/api-server_pod_spec_file_permissions.sh
+check_number="1.1.2" . ./checks/control_plane_components/configuration_files/api-server_pod_spec_file_ownership.sh
+check_number="1.1.3" . ./checks/control_plane_components/configuration_files/controller-manager_pod_spec_file_permissions.sh
+check_number="1.1.4" . ./checks/control_plane_components/configuration_files/controller-manager_pod_spec_file_ownership.sh
+check_number="1.1.5" . ./checks/control_plane_components/configuration_files/scheduler_pod_spec_file_permissions.sh
+check_number="1.1.6" . ./checks/control_plane_components/configuration_files/scheduler_pod_spec_file_ownership.sh
+check_number="1.1.7" . ./checks/control_plane_components/configuration_files/etcd_pod_spec_file_permissions.sh
+check_number="1.1.8" . ./checks/control_plane_components/configuration_files/etcd_pod_spec_file_ownership.sh
+check_number="1.1.9" . ./checks/control_plane_components/configuration_files/cni_file_permissions.sh
+check_number="1.1.10" . ./checks/control_plane_components/configuration_files/cni_file_ownership.sh
+check_number="1.1.11" . ./checks/control_plane_components/configuration_files/etcd_data_dir_permissions.sh
+check_number="1.1.12" . ./checks/control_plane_components/configuration_files/etcd_data_dir_ownership.sh
+check_number="1.1.13" . ./checks/control_plane_components/configuration_files/admin_conf_file_permissions.sh
+check_number="1.1.14" . ./checks/control_plane_components/configuration_files/admin_conf_file_ownership.sh
+check_number="1.1.15" . ./checks/control_plane_components/configuration_files/scheduler_conf_file_permissions.sh
+check_number="1.1.16" . ./checks/control_plane_components/configuration_files/scheduler_conf_file_ownership.sh
+check_number="1.1.17" . ./checks/control_plane_components/configuration_files/controller-manager_conf_file_permissions.sh
+check_number="1.1.18" . ./checks/control_plane_components/configuration_files/controller-manager_conf_file_ownership.sh
+check_number="1.1.19" . ./checks/control_plane_components/configuration_files/pki_directory_and_files_ownership.sh
+check_number="1.1.20" . ./checks/control_plane_components/configuration_files/pki_certs_permissions.sh
+check_number="1.1.21" . ./checks/control_plane_components/configuration_files/pki_keys_permissions.sh
+
+info "1.2 - API Server"
+check_number="1.2.1" . ./checks/control_plane_components/api-server/anonymous-auth_is_set_to_false.sh
+check_number="1.2.2" . ./checks/control_plane_components/api-server/basic-auth-file_is_not_set.sh
+check_number="1.2.3" . ./checks/control_plane_components/api-server/token-auth-file_is_not_set.sh
+check_number="1.2.4" . ./checks/control_plane_components/api-server/kubelet-https_is_set_to_true.sh
+check_number="1.2.5" . ./checks/control_plane_components/api-server/kubelet-client-certificate_and_kubelet-client-key_are_set.sh
+check_number="1.2.6" . ./checks/control_plane_components/api-server/kubelet-certificate-authority_is_set.sh
+check_number="1.2.7" . ./checks/control_plane_components/api-server/authorization-mode_is_not_set_to_AlwaysAllow.sh
+check_number="1.2.8" . ./checks/control_plane_components/api-server/authorization-mode_includes_Node.sh
+check_number="1.2.9" . ./checks/control_plane_components/api-server/authorization-mode_includes_RBAC.sh
+check_number="1.2.10" . ./checks/control_plane_components/api-server/admission_control_plugin_EventRateLimit_is_set.sh
+check_number="1.2.11" . ./checks/control_plane_components/api-server/admission_control_plugin_AlwaysAdmit_is_not_set.sh
+check_number="1.2.12" . ./checks/control_plane_components/api-server/admission_control_plugin_AlwaysPullImages_is_set.sh
+check_number="1.2.13" . ./checks/control_plane_components/api-server/admission_control_plugin_SecurityContextDeny_is_set_if_PodSecurityPolicy_is_not_used.sh
+check_number="1.2.14" . ./checks/control_plane_components/api-server/admission_control_plugin_ServiceAccount_is_set.sh
+check_number="1.2.15" . ./checks/control_plane_components/api-server/admission_control_plugin_NamespaceLifecycle_is_set.sh
+check_number="1.2.16" . ./checks/control_plane_components/api-server/admission_control_plugin_PodSecurityPolicy_is_set.sh
+check_number="1.2.17" . ./checks/control_plane_components/api-server/admission_control_plugin_NodeRestriction_is_set.sh
+check_number="1.2.18" . ./checks/control_plane_components/api-server/insecure-bind-address_is_not_set.sh
+check_number="1.2.19" . ./checks/control_plane_components/api-server/insecure-port_is_set_to_0.sh
+check_number="1.2.20" . ./checks/control_plane_components/api-server/secure-port_is_not_set_to_0.sh
+check_number="1.2.21" . ./checks/control_plane_components/api-server/profiling_is_set_to_false.sh
+check_number="1.2.22" . ./checks/control_plane_components/api-server/audit-log-path_is_set.sh
+check_number="1.2.23" . ./checks/control_plane_components/api-server/audit-log-maxage_is_set_to_30_or_appropriate.sh
+check_number="1.2.24" . ./checks/control_plane_components/api-server/audit-log-maxbackup_is_set_to_10_or_appropriate.sh
+check_number="1.2.25" . ./checks/control_plane_components/api-server/audit-log-maxsize_is_set_to_100_or_appropriate.sh
+check_number="1.2.26" . ./checks/control_plane_components/api-server/request-timeout_is_set.sh
+check_number="1.2.27" . ./checks/control_plane_components/api-server/service-account-lookup_is_set_to_true.sh
+check_number="1.2.28" . ./checks/control_plane_components/api-server/service-account-key-file_is_set.sh
+check_number="1.2.29" . ./checks/control_plane_components/api-server/etcd-certfile_and_etcd-keyfile_is_set.sh
+check_number="1.2.30" . ./checks/control_plane_components/api-server/tls-cert-file_and_tls-private-key-file_are_set.sh
+check_number="1.2.31" . ./checks/control_plane_components/api-server/client-ca-file_is_set.sh
+check_number="1.2.32" . ./checks/control_plane_components/api-server/etcd-cafile_is_set.sh
+check_number="1.2.33" . ./checks/control_plane_components/api-server/encryption-provider-config_is_set.sh
+check_number="1.2.34" . ./checks/control_plane_components/api-server/encryption_providers_are_appropriately_configured.sh
+check_number="1.2.35" . ./checks/control_plane_components/api-server/api-server_only_makes_use_of_strong_cryptographic_ciphers.sh
+
+info "1.3 - Controller Manager"
+check_number="1.3.1" . ./checks/control_plane_components/controller-manager/terminated-pod-gc-threshold_is_set.sh
+check_number="1.3.2" . ./checks/control_plane_components/controller-manager/profiling_is_set_to_false.sh
+check_number="1.3.3" . ./checks/control_plane_components/controller-manager/use-service-account-credentials_is_set_to_true.sh
+check_number="1.3.4" . ./checks/control_plane_components/controller-manager/service-account-private-key-file_is_set.sh
+check_number="1.3.5" . ./checks/control_plane_components/controller-manager/root-ca-file_is_set.sh
+check_number="1.3.6" . ./checks/control_plane_components/controller-manager/RotateKubeletServerCertificate_is_set_to_true.sh
+check_number="1.3.7" . ./checks/control_plane_components/controller-manager/bind-address_is_set_to_127_0_0_1.sh
+
+info "1.4 - Scheduler"
+check_number="1.4.1" . ./checks/control_plane_components/scheduler/profiling_is_set_to_false.sh
+check_number="1.4.2" . ./checks/control_plane_components/scheduler/bind-address_is_set_to_127_0_0_1.sh

--- a/1.6.0-refactor/master/2_etcd.sh
+++ b/1.6.0-refactor/master/2_etcd.sh
@@ -1,0 +1,8 @@
+info "2 - etcd"
+check_number="2.1" . ./checks/etcd/cert-file_and_key-file_are_set.sh
+check_number="2.2" . ./checks/etcd/client-cert-auth_is_set_to_true.sh
+check_number="2.3" . ./checks/etcd/auto-tls_is_not_set_to_true.sh
+check_number="2.4" . ./checks/etcd/peer-cert-file_and_peer-key-file_are_set.sh
+check_number="2.5" . ./checks/etcd/peer-client-cert-auth_is_set_to_true.sh
+check_number="2.6" . ./checks/etcd/peer-auto-tls_is_not_set_to_true.sh
+check_number="2.7" . ./checks/etcd/unique_Certificate_Authority_is_used.sh

--- a/1.6.0-refactor/master/3_control_plane_configuration.sh
+++ b/1.6.0-refactor/master/3_control_plane_configuration.sh
@@ -1,0 +1,8 @@
+info "3 - Control Plane Configuration"
+
+info "3.1 - Authentication and Authorization"
+check_number="3.1.1" . ./checks/control_plane_configuration/authn_and_authz/client_certificate_authentication_should_not_be_used_for_users.sh
+
+info "3.2 - Logging"
+check_number="3.2.1" . ./checks/control_plane_configuration/logging/a_minimal_audit_policy_is_created.sh
+check_number="3.2.2" . ./checks/control_plane_configuration/logging/the_audit_policy_covers_key_security_concerns.sh

--- a/1.6.0-refactor/master/5_policies.sh
+++ b/1.6.0-refactor/master/5_policies.sh
@@ -1,0 +1,38 @@
+info "5 - Policies"
+
+info "5.1 - RBAC and Service Accounts"
+check_number="5.1.1" . ./checks/policies/rbac_and_service_accounts/cluster-admin_role_is_only_used_where_required.sh
+check_number="5.1.2" . ./checks/policies/rbac_and_service_accounts/minimize_access_to_secrets.sh
+check_number="5.1.3" . ./checks/policies/rbac_and_service_accounts/minimize_wildcard_use_in_Roles_and_ClusterRoles.sh 
+check_number="5.1.4" . ./checks/policies/rbac_and_service_accounts/minimize_access_to_create_pods.sh
+check_number="5.1.5" . ./checks/policies/rbac_and_service_accounts/default_service_accounts_are_not_actively_used.sh
+check_number="5.1.6" . ./checks/policies/rbac_and_service_accounts/service_account_tokens_are_only_mounted_where_necessary.sh
+
+info "5.2 - Pod Security Policies"
+check_number="5.2.1" . ./checks/policies/pod_security_policies/minimize_admission_of_privileged_containers.sh
+check_number="5.2.2" . ./checks/policies/pod_security_policies/minimize_admission_of_containers_wishing_to_share_the_host_process_ID_namespace.sh
+check_number="5.2.3" . ./checks/policies/pod_security_policies/minimize_admission_of_containers_wishing_to_share_the_host_IPC_namespace.sh
+check_number="5.2.4" . ./checks/policies/pod_security_policies/minimize_admission_of_containers_wishing_to_share_the_host_network_namespace.sh
+check_number="5.2.5" . ./checks/policies/pod_security_policies/minimize_admission_of_containers_with_allowPrivilegeEscalation.sh
+check_number="5.2.6" . ./checks/policies/pod_security_policies/minimize_admission_of_root_containers.sh
+check_number="5.2.7" . ./checks/policies/pod_security_policies/minimize_admission_of_containers_with_the_NET_RAW_capability.sh
+check_number="5.2.8" . ./checks/policies/pod_security_policies/minimize_admission_of_containers_with_added_capabilities.sh
+check_number="5.2.9" . ./checks/policies/pod_security_policies/minimize_admission_of_containers_with_capabilities_assigned.sh
+
+info "5.3 - Network Policies and CNI"
+check_number="5.3.1" . ./checks/policies/network_policies_and_cni/CNI_in_use_supports_NetworkPolicies.sh
+check_number="5.3.2" . ./checks/policies/network_policies_and_cni/all_namespaces_have_NetworkPolicies.sh
+
+info "5.4 - Secrets Management"
+check_number="5.4.1" . ./checks/policies/secrets_management/prefer_using_secrets_as_files_over_environment_variables.sh
+check_number="5.4.2" . ./checks/policies/secrets_management/consider_external_secret_storage.sh
+
+info "5.5 - Extensible Admission Control"
+check_number="5.5.1" . ./checks/policies/extensible_admission_control/configure_image_provenance_using_ImagePolicyWebhook_admission_controller.sh
+
+info "5.7 - General Policies"
+check_number="5.7.1" . ./checks/policies/general_policies/create_administrative_boundaries_between_resources_using_namespaces.sh
+#todo remediation
+check_number="5.7.2" . ./checks/policies/general_policies/seccomp_profile_is_set_to_docker_default_in_your_pod_definitions.sh
+check_number="5.7.3" . ./checks/policies/general_policies/apply_security_context_to_your_pods_and_containers.sh
+check_number="5.7.4" . ./checks/policies/general_policies/the_default_namespace_should_not_be_used.sh

--- a/1.6.0-refactor/worker/4_worker_nodes.sh
+++ b/1.6.0-refactor/worker/4_worker_nodes.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+info "4.1 - Worker Node Configuration Files"
+check_number="4.1.1" . ./checks/worker_nodes/configuration_files/kubelet_service_file_permissions.sh
+check_number="4.1.2" . ./checks/worker_nodes/configuration_files/kubelet_service_file_ownership.sh
+check_number="4.1.3" . ./checks/worker_nodes/configuration_files/proxy_kubeconfig_file_permissions.sh
+check_number="4.1.4" . ./checks/worker_nodes/configuration_files/proxy_kubeconfig_file_ownership.sh
+check_number="4.1.5" . ./checks/worker_nodes/configuration_files/kubelet_conf_file_permissions.sh
+check_number="4.1.6" . ./checks/worker_nodes/configuration_files/kubelet_conf_file_ownership.sh
+check_number="4.1.7" . ./checks/worker_nodes/configuration_files/certificate_authorities_file_permissions.sh
+check_number="4.1.8" . ./checks/worker_nodes/configuration_files/client_certificate_authorities_file_ownership.sh
+check_number="4.1.9" . ./checks/worker_nodes/configuration_files/kubelet_configuration_file_permissions.sh
+check_number="4.1.10" . ./checks/worker_nodes/configuration_files/kubelet_configuration_file_ownership.sh
+
+info "4.2 - Kubelet"
+# todo review all audits
+check_number="4.2.1" . ./checks/worker_nodes/kubelet/anonymous-auth_is_set_to_false.sh
+check_number="4.2.2" . ./checks/worker_nodes/kubelet/authorization-mode_is_not_set_to_AlwaysAllow.sh
+check_number="4.2.3" . ./checks/worker_nodes/kubelet/client-ca-file_is_set.sh
+check_number="4.2.4" . ./checks/worker_nodes/kubelet/read-only-port_is_set_to_0.sh
+check_number="4.2.5" . ./checks/worker_nodes/kubelet/streaming-connection-idle-timeout_is_not_set_to_0.sh
+check_number="4.2.6" . ./checks/worker_nodes/kubelet/protect-kernel-defaults_is_set_to_true.sh
+check_number="4.2.7" . ./checks/worker_nodes/kubelet/make-iptables-util-chains_is_set_to_true.sh
+check_number="4.2.8" . ./checks/worker_nodes/kubelet/hostname-override_is_not_set.sh
+check_number="4.2.9" . ./checks/worker_nodes/kubelet/event-qps_is_set_to_0_or_appropriate.sh
+check_number="4.2.10" . ./checks/worker_nodes/kubelet/tls-cert-file_and_tls-private-key-file_are_set.sh
+check_number="4.2.11" . ./checks/worker_nodes/kubelet/rotate-certificates_is_not_set_to_false.sh
+check_number="4.2.12" . ./checks/worker_nodes/kubelet/RotateKubeletServerCertificate_is_set_to_true.sh
+check_number="4.2.13" . ./checks/worker_nodes/kubelet/kubelet_only_makes_use_of_strong_cryptographic_ciphers.sh

--- a/checks/control_plane_components/api-server/admission_control_plugin_AlwaysAdmit_is_not_set.sh
+++ b/checks/control_plane_components/api-server/admission_control_plugin_AlwaysAdmit_is_not_set.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+check_title="Ensure that the admission control plugin AlwaysAdmit is not set (Automated)"
+check="$check_number  - $check_title"
+
+if get_argument_value "$CIS_APISERVER_CMD" '--enable-admission-plugins'| grep 'AlwaysAdmit' >/dev/null 2>&1; then
+    warn "$check"
+else
+    pass "$check"
+fi

--- a/checks/control_plane_components/api-server/admission_control_plugin_AlwaysPullImages_is_set.sh
+++ b/checks/control_plane_components/api-server/admission_control_plugin_AlwaysPullImages_is_set.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+check_title="Ensure that the admission control plugin AlwaysPullImages is set (Manual)"
+check="$check_number  - $check_title"
+
+if get_argument_value "$CIS_APISERVER_CMD" '--enable-admission-plugins'| grep 'AlwaysPullImages' >/dev/null 2>&1; then
+    pass "$check"
+else
+    warn "$check"
+fi

--- a/checks/control_plane_components/api-server/admission_control_plugin_EventRateLimit_is_set.sh
+++ b/checks/control_plane_components/api-server/admission_control_plugin_EventRateLimit_is_set.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+check_title="Ensure that the admission control plugin EventRateLimit is set (Manual)"
+check="$check_number  - $check_title"
+
+if get_argument_value "$CIS_APISERVER_CMD" '--enable-admission-plugins'| grep 'EventRateLimit' >/dev/null 2>&1; then
+    pass "$check"
+else
+    warn "$check"
+fi

--- a/checks/control_plane_components/api-server/admission_control_plugin_NamespaceLifecycle_is_set.sh
+++ b/checks/control_plane_components/api-server/admission_control_plugin_NamespaceLifecycle_is_set.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+check_title="Ensure that the admission control plugin NamespaceLifecycle is set (Automated)"
+check="$check_number  - $check_title"
+
+if get_argument_value "$CIS_APISERVER_CMD" '--disable-admission-plugins'| grep 'NamespaceLifecycle' >/dev/null 2>&1; then
+    warn "$check"
+else
+    pass "$check"
+fi

--- a/checks/control_plane_components/api-server/admission_control_plugin_NodeRestriction_is_set.sh
+++ b/checks/control_plane_components/api-server/admission_control_plugin_NodeRestriction_is_set.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+check_title="Ensure that the admission control plugin NodeRestriction is set (Automated)"
+check="$check_number  - $check_title"
+
+if get_argument_value "$CIS_APISERVER_CMD" '--enable-admission-plugins'| grep 'NodeRestriction' >/dev/null 2>&1; then
+    pass "$check"
+else
+    warn "$check"
+fi

--- a/checks/control_plane_components/api-server/admission_control_plugin_PodSecurityPolicy_is_set.sh
+++ b/checks/control_plane_components/api-server/admission_control_plugin_PodSecurityPolicy_is_set.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+check_title="Ensure that the admission control plugin PodSecurityPolicy is set (Automated)"
+check="$check_number  - $check_title"
+
+if get_argument_value "$CIS_APISERVER_CMD" '--enable-admission-plugins'| grep 'PodSecurityPolicy' >/dev/null 2>&1; then
+    pass "$check"
+else
+    warn "$check"
+fi

--- a/checks/control_plane_components/api-server/admission_control_plugin_SecurityContextDeny_is_set_if_PodSecurityPolicy_is_not_used.sh
+++ b/checks/control_plane_components/api-server/admission_control_plugin_SecurityContextDeny_is_set_if_PodSecurityPolicy_is_not_used.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+check_title="Ensure that the admission control plugin SecurityContextDeny is set if PodSecurityPolicy is not used (Manual)"
+check="$check_number  - $check_title"
+
+if get_argument_value "$CIS_APISERVER_CMD" '--enable-admission-plugins'| grep 'PodSecurityPolicy' >/dev/null 2>&1; then
+    pass "$check"
+else
+  if get_argument_value "$CIS_APISERVER_CMD" '--enable-admission-plugins'| grep 'SecurityContextDeny' >/dev/null 2>&1; then
+    pass "$check"
+  else
+    warn "$check"
+  fi
+fi

--- a/checks/control_plane_components/api-server/admission_control_plugin_ServiceAccount_is_set.sh
+++ b/checks/control_plane_components/api-server/admission_control_plugin_ServiceAccount_is_set.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+check_title="Ensure that the admission control plugin ServiceAccount is set (Automated)"
+check="$check_number  - $check_title"
+
+if get_argument_value "$CIS_APISERVER_CMD" '--disable-admission-plugins'| grep 'ServiceAccount' >/dev/null 2>&1; then
+    warn "$check"
+else
+    pass "$check"
+fi

--- a/checks/control_plane_components/api-server/anonymous-auth_is_set_to_false.sh
+++ b/checks/control_plane_components/api-server/anonymous-auth_is_set_to_false.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+check_title="Ensure that the --anonymous-auth argument is set to false (Manual)"
+check="$check_number  - $check_title"
+
+if check_argument "$CIS_APISERVER_CMD" '--anonymous-auth=false' >/dev/null 2>&1; then
+    pass "$check"
+else
+    warn "$check"
+fi

--- a/checks/control_plane_components/api-server/api-server_only_makes_use_of_strong_cryptographic_ciphers.sh
+++ b/checks/control_plane_components/api-server/api-server_only_makes_use_of_strong_cryptographic_ciphers.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+check_title="Ensure that the API Server only makes use of Strong Cryptographic Ciphers (Manual)"
+check="$check_number  - $check_title"
+
+if check_argument "$CIS_APISERVER_CMD" '--tls-cipher-suites' >/dev/null 2>&1; then
+    ciphers=$(get_argument_value "$CIS_APISERVER_CMD" '--tls-cipher-suites'|cut -d " " -f 1)
+    found=$(echo $ciphers| sed -rn '/(TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256|TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256|TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305|TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384|TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305|TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384)/p')
+    if [ ! -z "$found" ]; then
+      pass "$check"
+    else
+      warn "$check"
+    fi
+else
+    warn "$check"
+fi

--- a/checks/control_plane_components/api-server/audit-log-maxage_is_set_to_30_or_appropriate.sh
+++ b/checks/control_plane_components/api-server/audit-log-maxage_is_set_to_30_or_appropriate.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+check_title="Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Automated)"
+check="$check_number  - $check_title"
+
+if check_argument "$CIS_APISERVER_CMD" '--audit-log-maxage' >/dev/null 2>&1; then
+    maxage=$(get_argument_value "$CIS_APISERVER_CMD" '--audit-log-maxage'|cut -d " " -f 1)
+    if [ "$maxage" -ge "30" ]; then
+        pass "$check"
+        pass "        * audit-log-maxage: $maxage"
+    else
+        warn "$check"
+        warn "        * audit-log-maxage: $maxage"
+    fi
+else
+    warn "$check"
+fi

--- a/checks/control_plane_components/api-server/audit-log-maxbackup_is_set_to_10_or_appropriate.sh
+++ b/checks/control_plane_components/api-server/audit-log-maxbackup_is_set_to_10_or_appropriate.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+check_title="Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Automated)"
+check="$check_number  - $check_title"
+
+if check_argument "$CIS_APISERVER_CMD" '--audit-log-maxbackup' >/dev/null 2>&1; then
+    maxbackup=$(get_argument_value "$CIS_APISERVER_CMD" '--audit-log-maxbackup'|cut -d " " -f 1)
+    if [ "$maxbackup" -ge "10" ]; then
+        pass "$check"
+        pass "        * audit-log-maxbackup: $maxbackup"
+    else
+        warn "$check"
+        warn "        * audit-log-maxbackup: $maxbackup"
+    fi
+else
+    warn "$check"
+fi

--- a/checks/control_plane_components/api-server/audit-log-maxsize_is_set_to_100_or_appropriate.sh
+++ b/checks/control_plane_components/api-server/audit-log-maxsize_is_set_to_100_or_appropriate.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+check_title="Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Automated)"
+check="$check_number  - $check_title"
+
+if check_argument "$CIS_APISERVER_CMD" '--audit-log-maxsize' >/dev/null 2>&1; then
+    maxsize=$(get_argument_value "$CIS_APISERVER_CMD" '--audit-log-maxsize'|cut -d " " -f 1)
+    if [ "$maxsize" -ge "100" ]; then
+        pass "$check"
+        pass "        * audit-log-maxsize: $maxsize"
+    else
+        warn "$check"
+        warn "        * audit-log-maxsize: $maxsize"
+    fi
+else
+    warn "$check"
+fi

--- a/checks/control_plane_components/api-server/audit-log-path_is_set.sh
+++ b/checks/control_plane_components/api-server/audit-log-path_is_set.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+check_title="Ensure that the --audit-log-path argument is set (Automated)"
+check="$check_number  - $check_title"
+
+if check_argument "$CIS_APISERVER_CMD" '--audit-log-path' >/dev/null 2>&1; then
+    pass "$check"
+else
+    warn "$check"
+fi

--- a/checks/control_plane_components/api-server/authorization-mode_includes_Node.sh
+++ b/checks/control_plane_components/api-server/authorization-mode_includes_Node.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+check_title="Ensure that the --authorization-mode argument includes Node (Automated)"
+check="$check_number  - $check_title"
+
+if get_argument_value "$CIS_APISERVER_CMD" '--authorization-mode'| grep 'Node' >/dev/null 2>&1; then
+    pass "$check"
+else
+    warn "$check"
+fi

--- a/checks/control_plane_components/api-server/authorization-mode_includes_RBAC.sh
+++ b/checks/control_plane_components/api-server/authorization-mode_includes_RBAC.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+check_title="Ensure that the --authorization-mode argument includes RBAC (Automated)"
+check="$check_number  - $check_title"
+
+if get_argument_value "$CIS_APISERVER_CMD" '--authorization-mode'| grep 'RBAC' >/dev/null 2>&1; then
+    pass "$check"
+else
+    warn "$check"
+fi

--- a/checks/control_plane_components/api-server/authorization-mode_is_not_set_to_AlwaysAllow.sh
+++ b/checks/control_plane_components/api-server/authorization-mode_is_not_set_to_AlwaysAllow.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+check_title="Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)"
+check="$check_number  - $check_title"
+
+if get_argument_value "$CIS_APISERVER_CMD" '--authorization-mode'| grep 'AlwaysAllow' >/dev/null 2>&1; then
+    warn "$check"
+else
+    pass "$check"
+fi

--- a/checks/control_plane_components/api-server/basic-auth-file_is_not_set.sh
+++ b/checks/control_plane_components/api-server/basic-auth-file_is_not_set.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+check_title="Ensure that the --basic-auth-file argument is not set (Automated)"
+check="$check_number  - $check_title"
+
+if check_argument "$CIS_APISERVER_CMD" '--basic-auth-file' >/dev/null 2>&1; then
+    warn "$check"
+else
+    pass "$check"
+fi

--- a/checks/control_plane_components/api-server/client-ca-file_is_set.sh
+++ b/checks/control_plane_components/api-server/client-ca-file_is_set.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+check_title="Ensure that the --client-ca-file argument is set as appropriate (Automated)"
+check="$check_number  - $check_title"
+
+if check_argument "$CIS_APISERVER_CMD" '--client-ca-file' >/dev/null 2>&1; then
+    cafile=$(get_argument_value "$CIS_APISERVER_CMD" '--client-ca-file')
+    pass "$check"
+    pass "        * client-ca-file: $cafile"
+else
+    warn "$check"
+fi

--- a/checks/control_plane_components/api-server/encryption-provider-config_is_set.sh
+++ b/checks/control_plane_components/api-server/encryption-provider-config_is_set.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+check_title="Ensure that the --encryption-provider-config argument is set as appropriate (Manual)"
+check="$check_number  - $check_title"
+
+if get_argument_value "$CIS_APISERVER_CMD" '--encryption-provider-config'| grep 'EncryptionConfig' >/dev/null 2>&1; then
+    pass "$check"
+else
+    warn "$check"
+fi

--- a/checks/control_plane_components/api-server/encryption_providers_are_appropriately_configured.sh
+++ b/checks/control_plane_components/api-server/encryption_providers_are_appropriately_configured.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+check_title="Ensure that encryption providers are appropriately configured (Manual)"
+check="$check_number  - $check_title"
+
+if check_argument "$CIS_APISERVER_CMD" '--encryption-provider-config' >/dev/null 2>&1; then
+    encryptionConfig=$(get_argument_value "$CIS_APISERVER_CMD" '--encryption-provider-config')
+    if [ -f "$encryptionConfig" ]; then
+      if [ $(grep -c "\- aescbc:\|\- kms:\|\- secretbox:" $encryptionConfig) -ne 0 ]; then
+        pass "$check"
+      else
+        warn "$check"
+      fi
+    else
+      warn "$check"
+    fi
+else
+    warn "$check"
+fi
+
+#if get_argument_value "$CIS_APISERVER_CMD" '--experimental-encryption-provider-config'| grep 'EncryptionConfig' >/dev/null 2>&1; then
+#    encryptionConfig=$(get_argument_value "$CIS_APISERVER_CMD" '--experimental-encryption-provider-config')
+#    if sed ':a;N;$!ba;s/\n/ /g' $encryptionConfig |grep "providers:\s* - aescbc" >/dev/null 2>&1; then
+#        pass "$check"
+#    else
+#        warn "$check"
+#    fi
+#else
+#    warn "$check"
+#fi

--- a/checks/control_plane_components/api-server/etcd-cafile_is_set.sh
+++ b/checks/control_plane_components/api-server/etcd-cafile_is_set.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+check_title="Ensure that the --etcd-cafile argument is set as appropriate (Automated)"
+check="$check_number  - $check_title"
+
+if check_argument "$CIS_APISERVER_CMD" '--etcd-cafile' >/dev/null 2>&1; then
+    cafile=$(get_argument_value "$CIS_APISERVER_CMD" '--etcd-cafile')
+    pass "$check"
+    pass "        * etcd-cafile: $cafile"
+else
+    warn "$check"
+fi

--- a/checks/control_plane_components/api-server/etcd-certfile_and_etcd-keyfile_is_set.sh
+++ b/checks/control_plane_components/api-server/etcd-certfile_and_etcd-keyfile_is_set.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+check_title="Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as appropriate (Automated)"
+check="$check_number  - $check_title"
+
+if check_argument "$CIS_APISERVER_CMD" '--etcd-certfile' >/dev/null 2>&1; then
+    if check_argument "$CIS_APISERVER_CMD" '--etcd-keyfile' >/dev/null 2>&1; then
+        certfile=$(get_argument_value "$CIS_APISERVER_CMD" '--etcd-certfile')
+        keyfile=$(get_argument_value "$CIS_APISERVER_CMD" '--etcd-keyfile')
+        pass "$check"
+        pass "        * etcd-certfile: $certfile"
+        pass "        * etcd-keyfile: $keyfile"
+    else
+        warn "$check"
+    fi
+else
+    warn "$check"
+fi

--- a/checks/control_plane_components/api-server/insecure-bind-address_is_not_set.sh
+++ b/checks/control_plane_components/api-server/insecure-bind-address_is_not_set.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+check_title="Ensure that the --insecure-bind-address argument is not set (Automated)"
+check="$check_number  - $check_title"
+
+if check_argument "$CIS_APISERVER_CMD" '--insecure-bind-address' >/dev/null 2>&1; then
+    warn "$check"
+else
+    pass "$check"
+fi

--- a/checks/control_plane_components/api-server/insecure-port_is_set_to_0.sh
+++ b/checks/control_plane_components/api-server/insecure-port_is_set_to_0.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+check_title="Ensure that the --insecure-port argument is set to 0 (Automated)"
+check="$check_number  - $check_title"
+
+if check_argument "$CIS_APISERVER_CMD" '--insecure-port' >/dev/null 2>&1; then
+    port=$(get_argument_value "$CIS_APISERVER_CMD" '--insecure-port'|cut -d " " -f 1)
+    if [ "$port" = "0" ]; then
+        pass "$check"
+    else
+        warn "$check"
+        warn "       * insecure-port: $port"
+    fi
+else
+    warn "$check"
+fi

--- a/checks/control_plane_components/api-server/kubelet-certificate-authority_is_set.sh
+++ b/checks/control_plane_components/api-server/kubelet-certificate-authority_is_set.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+check_title="Ensure that the --kubelet-certificate-authority argument is set as appropriate (Automated)"
+check="$check_number  - $check_title"
+
+if check_argument "$CIS_APISERVER_CMD" '--kubelet-certificate-authority' >/dev/null 2>&1; then
+    pass "$check"
+else
+    warn "$check"
+fi

--- a/checks/control_plane_components/api-server/kubelet-client-certificate_and_kubelet-client-key_are_set.sh
+++ b/checks/control_plane_components/api-server/kubelet-client-certificate_and_kubelet-client-key_are_set.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+check_title="Ensure that the --kubelet-client-certificate and --kubelet-client-key arguments are set as appropriate (Automated)"
+check="$check_number  - $check_title"
+
+if check_argument "$CIS_APISERVER_CMD" '--kubelet-client-certificate' >/dev/null 2>&1; then
+    if check_argument "$CIS_APISERVER_CMD" '--kubelet-client-key' >/dev/null 2>&1; then
+        certificate=$(get_argument_value "$CIS_APISERVER_CMD" '--kubelet-client-certificate')
+        key=$(get_argument_value "$CIS_APISERVER_CMD" '--kubelet-client-key')
+        pass "$check"
+        pass "       * kubelet-client-certificate: $certificate"
+        pass "       * kubelet-client-key: $key"
+    else
+        warn "$check"
+    fi
+else
+    warn "$check"
+fi

--- a/checks/control_plane_components/api-server/kubelet-https_is_set_to_true.sh
+++ b/checks/control_plane_components/api-server/kubelet-https_is_set_to_true.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+check_title="Ensure that the --kubelet-https argument is set to true (Automated)"
+check="$check_number  - $check_title"
+
+if check_argument "$CIS_APISERVER_CMD" '--kubelet-https=false' >/dev/null 2>&1; then
+    warn "$check"
+else
+    pass "$check"
+fi

--- a/checks/control_plane_components/api-server/profiling_is_set_to_false.sh
+++ b/checks/control_plane_components/api-server/profiling_is_set_to_false.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+check_title="Ensure that the --profiling argument is set to false (Automated)"
+check="$check_number  - $check_title"
+
+if check_argument "$CIS_APISERVER_CMD" '--profiling=false' >/dev/null 2>&1; then
+    pass "$check"
+else
+    warn "$check"
+fi

--- a/checks/control_plane_components/api-server/request-timeout_is_set.sh
+++ b/checks/control_plane_components/api-server/request-timeout_is_set.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+check_title="Ensure that the --request-timeout argument is set as appropriate (Automated)"
+check="$check_number  - $check_title"
+
+if check_argument "$CIS_APISERVER_CMD" '--request-timeout' >/dev/null 2>&1; then
+    requestTimeout=$(get_argument_value "$CIS_APISERVER_CMD" '--request-timeout')
+    warn "$check"
+    warn "        * request-timeout: $requestTimeout"
+else
+    pass "$check"
+fi

--- a/checks/control_plane_components/api-server/secure-port_is_not_set_to_0.sh
+++ b/checks/control_plane_components/api-server/secure-port_is_not_set_to_0.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+check_title="Ensure that the --secure-port argument is not set to 0 (Automated)"
+check="$check_number  - $check_title"
+
+if check_argument "$CIS_APISERVER_CMD" '--secure-port' >/dev/null 2>&1; then
+    port=$(get_argument_value "$CIS_APISERVER_CMD" '--secure-port'|cut -d " " -f 1)
+    if [ "$port" = "0" ]; then
+        warn "$check"
+        warn "       * secure-port: $port"
+    else
+        pass "$check"
+    fi
+else
+    pass "$check"
+fi

--- a/checks/control_plane_components/api-server/service-account-key-file_is_set.sh
+++ b/checks/control_plane_components/api-server/service-account-key-file_is_set.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+check_title="Ensure that the --service-account-key-file argument is set as appropriate (Automated)"
+check="$check_number  - $check_title"
+
+if check_argument "$CIS_APISERVER_CMD" '--service-account-key-file' >/dev/null 2>&1; then
+    file=$(get_argument_value "$CIS_APISERVER_CMD" '--service-account-key-file')
+    pass "$check"
+    pass "        * service-account-key-file: $file"
+else
+    warn "$check"
+fi

--- a/checks/control_plane_components/api-server/service-account-lookup_is_set_to_true.sh
+++ b/checks/control_plane_components/api-server/service-account-lookup_is_set_to_true.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+check_title="Ensure that the --service-account-lookup argument is set to true (Automated)"
+check="$check_number  - $check_title"
+
+if check_argument "$CIS_APISERVER_CMD" '--service-account-lookup=false' >/dev/null 2>&1; then
+    warn "$check"
+else
+    pass "$check"
+fi

--- a/checks/control_plane_components/api-server/tls-cert-file_and_tls-private-key-file_are_set.sh
+++ b/checks/control_plane_components/api-server/tls-cert-file_and_tls-private-key-file_are_set.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+check_title="Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Automated)"
+check="$check_number  - $check_title"
+
+if check_argument "$CIS_APISERVER_CMD" '--tls-cert-file' >/dev/null 2>&1; then
+    if check_argument "$CIS_APISERVER_CMD" '--tls-private-key-file' >/dev/null 2>&1; then
+        certfile=$(get_argument_value "$CIS_APISERVER_CMD" '--tls-cert-file')
+        keyfile=$(get_argument_value "$CIS_APISERVER_CMD" '--tls-private-key-file')
+        pass "$check"
+        pass "        * tls-cert-file: $certfile"
+        pass "        * tls-private-key-file: $keyfile"
+    else
+        warn "$check"
+    fi
+else
+    warn "$check"
+fi

--- a/checks/control_plane_components/api-server/token-auth-file_is_not_set.sh
+++ b/checks/control_plane_components/api-server/token-auth-file_is_not_set.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+check_title="Ensure that the --token-auth-file parameter is not set (Automated)"
+check="$check_number  - $check_title"
+
+if check_argument "$CIS_APISERVER_CMD" '--token-auth-file' >/dev/null 2>&1; then
+    warn "$check"
+else
+    pass "$check"
+fi

--- a/checks/control_plane_components/configuration_files/admin_conf_file_ownership.sh
+++ b/checks/control_plane_components/configuration_files/admin_conf_file_ownership.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+check_title="Ensure that the admin.conf file ownership is set to root:root (Automated)"
+check="$check_number  - $check_title"
+
+file="/etc/kubernetes/admin.conf"
+
+if [ -f "$file" ]; then
+  if [ "$(stat -c %u%g $file)" -eq 00 ]; then
+    pass "$check"
+  else
+    warn "$check"
+    warn "     * Wrong ownership for $file"
+  fi
+else
+  info "$check"
+fi

--- a/checks/control_plane_components/configuration_files/admin_conf_file_permissions.sh
+++ b/checks/control_plane_components/configuration_files/admin_conf_file_permissions.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+check_title="Ensure that the admin.conf file permissions are set to 644 or more restrictive (Automated)"
+check="$check_number  - $check_title"
+
+file="/etc/kubernetes/admin.conf"
+
+if [ -f "$file" ]; then
+  if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
+    pass "$check"
+  else
+    warn "$check"
+    warn "     * Wrong permissions for $file"
+  fi
+else
+  info "$check"
+  info "     * File not found"
+fi

--- a/checks/control_plane_components/configuration_files/api-server_pod_spec_file_ownership.sh
+++ b/checks/control_plane_components/configuration_files/api-server_pod_spec_file_ownership.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+check_title="Ensure that the API server pod specification file ownership is set to root:root (Automated)"
+check="$check_number  - $check_title"
+
+if [ -f "/etc/kubernetes/manifests/kube-apiserver.manifest" ]; then
+    # kops
+    file="/etc/kubernetes/manifests/kube-apiserver.manifest"
+else
+    file="/etc/kubernetes/manifests/kube-apiserver.yaml"
+fi
+
+if [ -f "$file" ]; then
+  if [ "$(stat -c %u%g $file)" -eq 00 ]; then
+    pass "$check"
+  else
+    warn "$check"
+    warn "     * Wrong ownership for $file"
+  fi
+else
+  info "$check"
+fi

--- a/checks/control_plane_components/configuration_files/api-server_pod_spec_file_permissions.sh
+++ b/checks/control_plane_components/configuration_files/api-server_pod_spec_file_permissions.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+check_title="Ensure that the API server pod specification file permissions are set to 644 or more restrictive (Automated)"
+check="$check_number  - $check_title"
+
+if [ -f "/etc/kubernetes/manifests/kube-apiserver.manifest" ]; then
+    # kops
+    file="/etc/kubernetes/manifests/kube-apiserver.manifest"
+else
+    file="/etc/kubernetes/manifests/kube-apiserver.yaml"
+fi
+
+if [ -f $file ]; then
+  if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 640 -o "$(stat -c %a $file)" -eq 600 ]; then
+    pass "$check"
+  else
+    warn "$check"
+    warn "     * Wrong permissions for $file"
+  fi
+else
+  info "$check"
+  info "     * File not found"
+fi

--- a/checks/control_plane_components/configuration_files/cni_file_ownership.sh
+++ b/checks/control_plane_components/configuration_files/cni_file_ownership.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+check_title="Ensure that the Container Network Interface file ownership is set to root:root (Manual)"
+check="$check_number  - $check_title"
+
+# todo find CNI file location
+
+info "$check
+       Audit:
+       Run the below command (based on the file location on your system) on the master node. For example,
+       stat -c %U:%G <path/to/cni/files>
+       Verify that the ownership is set to root:root."

--- a/checks/control_plane_components/configuration_files/cni_file_permissions.sh
+++ b/checks/control_plane_components/configuration_files/cni_file_permissions.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+check_title="Ensure that the Container Network Interface file permissions are set to 644 or more restrictive (Manual)"
+check="$check_number  - $check_title"
+
+# todo find CNI file location
+
+info "$check
+       Audit:
+       Run the below command (based on the file location on your system) on the master node. For example,
+       stat -c %a <path/to/cni/files>
+       Verify that the permissions are 644 or more restrictive."

--- a/checks/control_plane_components/configuration_files/controller-manager_conf_file_ownership.sh
+++ b/checks/control_plane_components/configuration_files/controller-manager_conf_file_ownership.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+check_title="Ensure that the controller-manager.conf file ownership is set to root:root (Automated)"
+check="$check_number  - $check_title"
+
+file="/etc/kubernetes/controller-manager.conf"
+
+if [ -f "$file" ]; then
+  if [ "$(stat -c %u%g $file)" -eq 00 ]; then
+    pass "$check"
+  else
+    warn "$check"
+    warn "     * Wrong ownership for $file"
+  fi
+else
+  info "$check"
+fi

--- a/checks/control_plane_components/configuration_files/controller-manager_conf_file_permissions.sh
+++ b/checks/control_plane_components/configuration_files/controller-manager_conf_file_permissions.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+check_title="Ensure that the controller-manager.conf file permissions are set to 644 or more restrictive (Automated)"
+check="$check_number  - $check_title"
+
+file="/etc/kubernetes/controller-manager.conf"
+
+if [ -f "$file" ]; then
+  if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
+    pass "$check"
+  else
+    warn "$check"
+    warn "     * Wrong permissions for $file"
+  fi
+else
+  info "$check"
+  info "     * File not found"
+fi

--- a/checks/control_plane_components/configuration_files/controller-manager_pod_spec_file_ownership.sh
+++ b/checks/control_plane_components/configuration_files/controller-manager_pod_spec_file_ownership.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+check_title="Ensure that the controller manager pod specification file ownership is set to root:root (Automated)"
+check="$check_number  - $check_title"
+
+if [ -f "$file" ]; then
+  if [ "$(stat -c %u%g $file)" -eq 00 ]; then
+    pass "$check"
+  else
+    warn "$check"
+    warn "     * Wrong ownership for $file"
+  fi
+else
+  info "$check"
+fi

--- a/checks/control_plane_components/configuration_files/controller-manager_pod_spec_file_permissions.sh
+++ b/checks/control_plane_components/configuration_files/controller-manager_pod_spec_file_permissions.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+check_title="Ensure that the controller manager pod specification file permissions are set to 644 or more restrictive (Automated)"
+check="$check_number  - $check_title"
+
+if [ -f "/etc/kubernetes/manifests/kube-controller-manager.manifest" ]; then
+    # kops
+    file="/etc/kubernetes/manifests/kube-controller-manager.manifest"
+else
+    file="/etc/kubernetes/manifests/kube-controller-manager.yaml"
+fi
+
+if [ -f "$file" ]; then
+  if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
+    pass "$check"
+  else
+    warn "$check"
+    warn "     * Wrong permissions for $file"
+  fi
+else
+  info "$check"
+  info "     * File not found"
+fi

--- a/checks/control_plane_components/configuration_files/etcd_data_dir_ownership.sh
+++ b/checks/control_plane_components/configuration_files/etcd_data_dir_ownership.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+check_title="Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"
+check="$check_number  - $check_title"
+
+file=""
+if check_argument "$CIS_ETCD_CMD" '--data-dir' >/dev/null 2>&1; then
+    file=$(get_argument_value "$CIS_ETCD_CMD" '--data-dir'|cut -d " " -f 1)
+fi
+
+if [ -f "$file" ]; then
+  if [ "$(stat -c %U:%G $file)" = "etcd:etcd" ]; then
+    pass "$check"
+  else
+    warn "$check"
+    warn "     * Wrong ownership for $file"
+  fi
+else
+  info "$check"
+  info "     * etcd data directory not found."
+fi

--- a/checks/control_plane_components/configuration_files/etcd_data_dir_permissions.sh
+++ b/checks/control_plane_components/configuration_files/etcd_data_dir_permissions.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+check_title="Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
+check="$check_number  - $check_title"
+
+file=""
+if check_argument "$CIS_ETCD_CMD" '--data-dir' >/dev/null 2>&1; then
+    file=$(get_argument_value "$CIS_ETCD_CMD" '--data-dir'|cut -d " " -f 1)
+fi
+
+if [ -f "$file" ]; then
+  if [ "$(stat -c %a $file)" -eq 700 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
+    pass "$check"
+  else
+    warn "$check"
+    warn "     * Wrong permissions for $file"
+  fi
+else
+  info "$check"
+  info "     * etcd data directory not found."
+fi

--- a/checks/control_plane_components/configuration_files/etcd_pod_spec_file_ownership.sh
+++ b/checks/control_plane_components/configuration_files/etcd_pod_spec_file_ownership.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+check_title="Ensure that the etcd pod specification file ownership is set to root:root (Automated)"
+check="$check_number  - $check_title"
+
+if [ -f "/etc/kubernetes/manifests/etcd.yaml" ]; then
+    file="/etc/kubernetes/manifests/etcd.yaml"
+else
+    # kops
+    file="/etc/kubernetes/manifests/etcd.manifest"
+fi
+
+if [ -f "$file" ]; then
+  if [ "$(stat -c %u%g $file)" -eq 00 ]; then
+    pass "$check"
+  else
+    warn "$check"
+    warn "     * Wrong ownership for $file"
+  fi
+else
+  info "$check"
+fi

--- a/checks/control_plane_components/configuration_files/etcd_pod_spec_file_permissions.sh
+++ b/checks/control_plane_components/configuration_files/etcd_pod_spec_file_permissions.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+check_title="Ensure that the etcd pod specification file permissions are set to 644 or more restrictive (Automated)"
+check="$check_number  - $check_title"
+
+if [ -f "/etc/kubernetes/manifests/etcd.yaml" ]; then
+    file="/etc/kubernetes/manifests/etcd.yaml"
+else
+    # kops
+    file="/etc/kubernetes/manifests/etcd.manifest"
+fi
+
+if [ -f "$file" ]; then
+  if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
+    pass "$check"
+  else
+    warn "$check"
+    warn "     * Wrong permissions for $file"
+  fi
+else
+  info "$check"
+  info "     * File not found"
+fi

--- a/checks/control_plane_components/configuration_files/pki_certs_permissions.sh
+++ b/checks/control_plane_components/configuration_files/pki_certs_permissions.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+check_title="Ensure that the Kubernetes PKI certificate file permissions are set to 644 or more restrictive (Manual)"
+check="$check_number  - $check_title"
+
+file="/etc/kubernetes/pki/"
+
+files=$(find $file -name "*.crt")
+pass=true
+for f in ${files}; do
+  if ! [ "$(stat -c %a $f)" -eq 644 -o "$(stat -c %a $f)" -eq 600 -o "$(stat -c %a $f)" -eq 400 ]; then
+    pass=false;
+    break;
+  fi
+done
+
+if [ "$pass" = "true" ]; then
+  pass "$check"
+else
+  warn "$check"
+fi

--- a/checks/control_plane_components/configuration_files/pki_directory_and_files_ownership.sh
+++ b/checks/control_plane_components/configuration_files/pki_directory_and_files_ownership.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+check_title="Ensure that the Kubernetes PKI directory and file ownership is set to root:root (Automated)"
+check="$check_number  - $check_title"
+
+file="/etc/kubernetes/pki/"
+
+files=$(find $file)
+pass=true
+for f in ${files}; do
+  if [ "$(stat -c %u%g $f)" != 00 ]; then
+    pass=false;
+    break;
+  fi
+done
+
+if [ "$pass" = "true" ]; then
+  pass "$check"
+else
+  warn "$check"
+fi

--- a/checks/control_plane_components/configuration_files/pki_keys_permissions.sh
+++ b/checks/control_plane_components/configuration_files/pki_keys_permissions.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+check_title="Ensure that the Kubernetes PKI key file permissions are set to 600 (Manual)"
+check="$check_number  - $check_title"
+
+file="/etc/kubernetes/pki/"
+
+files=$(find $file -name "*.key")
+pass=true
+for f in ${files}; do
+  if ! [ "$(stat -c %a $f)" -eq 600 ]; then
+    pass=false;
+    break;
+  fi
+done
+
+if [ "$pass" = "true" ]; then
+  pass "$check"
+else
+  warn "$check"
+fi

--- a/checks/control_plane_components/configuration_files/scheduler_conf_file_ownership.sh
+++ b/checks/control_plane_components/configuration_files/scheduler_conf_file_ownership.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+check_title="Ensure that the scheduler.conf file ownership is set to root:root (Automated)"
+check="$check_number  - $check_title"
+
+file="/etc/kubernetes/scheduler.conf"
+
+if [ -f "$file" ]; then
+  if [ "$(stat -c %u%g $file)" -eq 00 ]; then
+    pass "$check"
+  else
+    warn "$check"
+    warn "     * Wrong ownership for $file"
+  fi
+else
+  info "$check"
+fi

--- a/checks/control_plane_components/configuration_files/scheduler_conf_file_permissions.sh
+++ b/checks/control_plane_components/configuration_files/scheduler_conf_file_permissions.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+check_title="Ensure that the scheduler.conf file permissions are set to 644 or more restrictive (Automated)"
+check="$check_number  - $check_title"
+
+file="/etc/kubernetes/scheduler.conf"
+
+if [ -f "$file" ]; then
+  if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
+    pass "$check"
+  else
+    warn "$check"
+    warn "     * Wrong permissions for $file"
+  fi
+else
+  info "$check"
+  info "     * File not found"
+fi

--- a/checks/control_plane_components/configuration_files/scheduler_pod_spec_file_ownership.sh
+++ b/checks/control_plane_components/configuration_files/scheduler_pod_spec_file_ownership.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+check_title="Ensure that the scheduler pod specification file ownership is set to root:root (Automated)"
+check="$check_number  - $check_title"
+
+if [ -f "$file" ]; then
+  if [ "$(stat -c %u%g $file)" -eq 00 ]; then
+    pass "$check"
+  else
+    warn "$check"
+    warn "     * Wrong ownership for $file"
+  fi
+else
+  info "$check"
+fi

--- a/checks/control_plane_components/configuration_files/scheduler_pod_spec_file_permissions.sh
+++ b/checks/control_plane_components/configuration_files/scheduler_pod_spec_file_permissions.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+check_title="Ensure that the scheduler pod specification file permissions are set to 644 or more restrictive (Automated)"
+check="$check_number  - $check_title"
+
+if [ -f "/etc/kubernetes/manifests/kube-scheduler.yaml" ]; then
+    file="/etc/kubernetes/manifests/kube-scheduler.yaml"
+else
+    # kops
+    file="/etc/kubernetes/manifests/kube-scheduler.manifest"
+fi
+
+if [ -f "$file" ]; then
+  if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
+    pass "$check"
+  else
+    warn "$check"
+    warn "     * Wrong permissions for $file"
+  fi
+else
+  info "$check"
+  info "     * File not found"
+fi

--- a/checks/control_plane_components/controller-manager/RotateKubeletServerCertificate_is_set_to_true.sh
+++ b/checks/control_plane_components/controller-manager/RotateKubeletServerCertificate_is_set_to_true.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+check_title="Ensure that the RotateKubeletServerCertificate argument is set to true (Automated)"
+check="$check_number  - $check_title"
+
+if check_argument "$CIS_MANAGER_CMD" '--feature-gates' >/dev/null 2>&1; then
+    serverCert=$(get_argument_value "$CIS_MANAGER_CMD" '--feature-gates')
+    found=$(echo $serverCert| grep 'RotateKubeletServerCertificate=true')
+    if [ ! -z $found ]; then
+      pass "$check"
+    else
+      warn "$check"
+    fi
+else
+    warn "$check"
+fi

--- a/checks/control_plane_components/controller-manager/bind-address_is_set_to_127_0_0_1.sh
+++ b/checks/control_plane_components/controller-manager/bind-address_is_set_to_127_0_0_1.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+check_title="Ensure that the --bind-address argument is set to 127.0.0.1 (Automated)"
+check="$check_number  - $check_title"
+
+if get_argument_value "$CIS_MANAGER_CMD" '--bind-address'| grep '127.0.0.1' >/dev/null 2>&1; then
+    pass "$check"
+else
+    warn "$check"
+fi

--- a/checks/control_plane_components/controller-manager/profiling_is_set_to_false.sh
+++ b/checks/control_plane_components/controller-manager/profiling_is_set_to_false.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+check_title="Ensure that the --profiling argument is set to false (Automated)"
+check="$check_number  - $check_title"
+
+if check_argument "$CIS_MANAGER_CMD" '--profiling=false' >/dev/null 2>&1; then
+    pass "$check"
+else
+    warn "$check"
+fi

--- a/checks/control_plane_components/controller-manager/root-ca-file_is_set.sh
+++ b/checks/control_plane_components/controller-manager/root-ca-file_is_set.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+check_title="Ensure that the --root-ca-file argument is set as appropriate (Automated)"
+check="$check_number  - $check_title"
+
+if check_argument "$CIS_MANAGER_CMD" '--root-ca-file' >/dev/null 2>&1; then
+    cafile=$(get_argument_value "$CIS_MANAGER_CMD" '--root-ca-file')
+    pass "$check"
+    pass "       * root-ca-file: $cafile"
+else
+    warn "$check"
+fi

--- a/checks/control_plane_components/controller-manager/service-account-private-key-file_is_set.sh
+++ b/checks/control_plane_components/controller-manager/service-account-private-key-file_is_set.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+check_title="Ensure that the --service-account-private-key-file argument is set as appropriate (Automated)"
+check="$check_number  - $check_title"
+
+if check_argument "$CIS_MANAGER_CMD" '--service-account-private-key-file' >/dev/null 2>&1; then
+    keyfile=$(get_argument_value "$CIS_MANAGER_CMD" '--service-account-private-key-file')
+    pass "$check"
+    pass "       * service-account-private-key-file: $keyfile"
+else
+    warn "$check"
+fi

--- a/checks/control_plane_components/controller-manager/terminated-pod-gc-threshold_is_set.sh
+++ b/checks/control_plane_components/controller-manager/terminated-pod-gc-threshold_is_set.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+check_title="Ensure that the --terminated-pod-gc-threshold argument is set as appropriate (Manual)"
+check="$check_number  - $check_title"
+
+# Filter out processes like "/bin/tee -a /var/log/kube-controller-manager.log"
+# which exist on kops-managed clusters.
+if check_argument "$CIS_MANAGER_CMD" '--terminated-pod-gc-threshold' >/dev/null 2>&1; then
+    threshold=$(get_argument_value "$CIS_MANAGER_CMD" '--terminated-pod-gc-threshold')
+    pass "$check"
+    pass "       * terminated-pod-gc-threshold: $threshold"
+else
+    warn "$check"
+fi

--- a/checks/control_plane_components/controller-manager/use-service-account-credentials_is_set_to_true.sh
+++ b/checks/control_plane_components/controller-manager/use-service-account-credentials_is_set_to_true.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+check_title="Ensure that the --use-service-account-credentials argument is set to true (Automated)"
+check="$check_number  - $check_title"
+
+if check_argument "$CIS_MANAGER_CMD" '--use-service-account-credentials=true' >/dev/null 2>&1; then
+    pass "$check"
+else
+    warn "$check"
+fi

--- a/checks/control_plane_components/scheduler/bind-address_is_set_to_127_0_0_1.sh
+++ b/checks/control_plane_components/scheduler/bind-address_is_set_to_127_0_0_1.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+check_title="Ensure that the --bind-address argument is set to 127.0.0.1 (Automated)"
+check="$check_number  - $check_title"
+
+if get_argument_value "$CIS_SCHEDULER_CMD" '--bind-address'| grep '127.0.0.1' >/dev/null 2>&1; then
+  	pass "$check"
+else
+  	warn "$check"
+fi

--- a/checks/control_plane_components/scheduler/profiling_is_set_to_false.sh
+++ b/checks/control_plane_components/scheduler/profiling_is_set_to_false.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+check_title="Ensure that the --profiling argument is set to false (Automated)"
+check="$check_number  - $check_title"
+
+if check_argument "$CIS_SCHEDULER_CMD" '--profiling=false' >/dev/null 2>&1; then
+  	pass "$check"
+else
+  	warn "$check"
+fi

--- a/checks/control_plane_configuration/authn_and_authz/client_certificate_authentication_should_not_be_used_for_users.sh
+++ b/checks/control_plane_configuration/authn_and_authz/client_certificate_authentication_should_not_be_used_for_users.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+check_title="Client certificate authentication should not be used for users (Manual)"
+check="$check_number  - $check_title"
+
+info "$check"
+info "        * Review user access to the cluster and ensure that users are not making use of Kubernetes client certificate authentication."

--- a/checks/control_plane_configuration/logging/a_minimal_audit_policy_is_created.sh
+++ b/checks/control_plane_configuration/logging/a_minimal_audit_policy_is_created.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+check_title="Ensure that a minimal audit policy is created (Manual)"
+check="$check_number  - $check_title"
+
+if check_argument "$CIS_APISERVER_CMD" '--audit-policy-file' >/dev/null 2>&1; then
+    auditPolicyFile=$(get_argument_value "$CIS_APISERVER_CMD" '--audit-policy-file')
+    pass "$check"
+    pass "        * audit-policy-file: $auditPolicyFile"
+else
+    warn "$check"
+fi

--- a/checks/control_plane_configuration/logging/the_audit_policy_covers_key_security_concerns.sh
+++ b/checks/control_plane_configuration/logging/the_audit_policy_covers_key_security_concerns.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+check_title="Ensure that the audit policy covers key security concerns (Manual)"
+check="$check_number  - $check_title"
+
+info "$check"
+info "        * Access to Secrets managed by the cluster. Care should be taken to only log Metadata for requests to Secrets, ConfigMaps, and TokenReviews, in order to avoid the risk of logging sensitive data."
+info "        * Modification of pod and deployment objects."
+info "        * Use of pods/exec, pods/portforward, pods/proxy and services/proxy."

--- a/checks/etcd/auto-tls_is_not_set_to_true.sh
+++ b/checks/etcd/auto-tls_is_not_set_to_true.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+check_title="Ensure that the --auto-tls argument is not set to true (Automated)"
+check="$check_number  - $check_title"
+
+if check_argument "$CIS_ETCD_CMD" '--auto-tls=true' >/dev/null 2>&1; then
+    warn "$check"
+else
+    pass "$check"
+fi

--- a/checks/etcd/cert-file_and_key-file_are_set.sh
+++ b/checks/etcd/cert-file_and_key-file_are_set.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+check_title="Ensure that the --cert-file and --key-file arguments are set as appropriate (Automated)"
+check="$check_number  - $check_title"
+
+if check_argument "$CIS_ETCD_CMD" '--cert-file' >/dev/null 2>&1; then
+    if check_argument "$CIS_ETCD_CMD" '--key-file' >/dev/null 2>&1; then
+        cfile=$(get_argument_value "$CIS_ETCD_CMD" '--cert-file')
+        kfile=$(get_argument_value "$CIS_ETCD_CMD" '--key-file')
+        pass "$check"
+        pass "       * cert-file: $cfile"
+        pass "       * key-file: $kfile"
+    else
+      warn "$check"
+    fi
+else
+    warn "$check"
+fi

--- a/checks/etcd/client-cert-auth_is_set_to_true.sh
+++ b/checks/etcd/client-cert-auth_is_set_to_true.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+check_title="Ensure that the --client-cert-auth argument is set to true (Automated)"
+check="$check_number  - $check_title"
+
+if check_argument "$CIS_ETCD_CMD" '--client-cert-auth' >/dev/null 2>&1; then
+    pass "$check"
+else
+    warn "$check"
+fi

--- a/checks/etcd/peer-auto-tls_is_not_set_to_true.sh
+++ b/checks/etcd/peer-auto-tls_is_not_set_to_true.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+check_title="Ensure that the --peer-auto-tls argument is not set to true (Automated)"
+check="$check_number  - $check_title"
+
+if check_argument "$CIS_ETCD_CMD" '--peer-auto-tls=true' >/dev/null 2>&1; then
+    warn "$check"
+else
+    pass "$check"
+fi

--- a/checks/etcd/peer-cert-file_and_peer-key-file_are_set.sh
+++ b/checks/etcd/peer-cert-file_and_peer-key-file_are_set.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+check_title="Ensure that the --peer-cert-file and --peer-key-file arguments are set as appropriate (Automated)"
+check="$check_number  - $check_title"
+
+if check_argument "$CIS_ETCD_CMD" '--peer-cert-file' >/dev/null 2>&1; then
+    if check_argument "$CIS_ETCD_CMD" '--peer-key-file' >/dev/null 2>&1; then
+        cfile=$(get_argument_value "$CIS_ETCD_CMD" '--peer-cert-file')
+        kfile=$(get_argument_value "$CIS_ETCD_CMD" '--peer-key-file')
+        pass "$check"
+        pass "       * peer-cert-file: $cfile"
+        pass "       * peer-key-file: $kfile"
+    else
+          warn "$check"
+    fi
+else
+    warn "$check"
+fi

--- a/checks/etcd/peer-client-cert-auth_is_set_to_true.sh
+++ b/checks/etcd/peer-client-cert-auth_is_set_to_true.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+check_title="Ensure that the --peer-client-cert-auth argument is set to true (Automated)"
+check="$check_number  - $check_title"
+
+if check_argument "$CIS_ETCD_CMD" '--peer-client-cert-auth=true' >/dev/null 2>&1; then
+    pass "$check"
+else
+    warn "$check"
+fi

--- a/checks/etcd/unique_Certificate_Authority_is_used.sh
+++ b/checks/etcd/unique_Certificate_Authority_is_used.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+check_title="Ensure that a unique Certificate Authority is used for etcd (Manual)"
+check="$check_number  - $check_title"
+
+#todo apiserver vs kube-apiserver
+
+if check_argument "$CIS_ETCD_CMD" '--trusted-ca-file' >/dev/null 2>&1; then
+    if check_argument "$CIS_APISERVER_CMD" '--client-ca-file' >/dev/null 2>&1; then
+        tfile=$(get_argument_value "$CIS_ETCD_CMD" '--trusted-ca-file')
+        cfile=$(get_argument_value "$CIS_APISERVER_CMD" '--client-ca-file')
+        if [ "$tfile" = "$cfile" ]; then
+            pass "$check"
+            pass "       * trusted-ca-file: $tfile"
+            pass "       * client-ca-file: $cfile"
+        else
+          warn "$check"
+        fi
+    else
+        warn "$check"
+        warn "       * client-ca-file doesn't exist"
+    fi
+else
+    warn "$check"
+    warn "       * trusted-ca-file doesn't exist"
+fi

--- a/checks/policies/extensible_admission_control/configure_image_provenance_using_ImagePolicyWebhook_admission_controller.sh
+++ b/checks/policies/extensible_admission_control/configure_image_provenance_using_ImagePolicyWebhook_admission_controller.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+check_title="Configure Image Provenance using ImagePolicyWebhook admission controller (Manual)"
+check="$check_number  - $check_title"
+
+# TODO
+
+info "$check"

--- a/checks/policies/general_policies/apply_security_context_to_your_pods_and_containers.sh
+++ b/checks/policies/general_policies/apply_security_context_to_your_pods_and_containers.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+check_title="Apply Security Context to Your Pods and Containers (Manual)"
+check="$check_number  - $check_title"
+
+# TODO
+
+info "$check"

--- a/checks/policies/general_policies/create_administrative_boundaries_between_resources_using_namespaces.sh
+++ b/checks/policies/general_policies/create_administrative_boundaries_between_resources_using_namespaces.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+check_title="Create administrative boundaries between resources using namespaces (Manual)"
+check="$check_number  - $check_title"
+
+# TODO
+
+info "$check"

--- a/checks/policies/general_policies/seccomp_profile_is_set_to_docker_default_in_your_pod_definitions.sh
+++ b/checks/policies/general_policies/seccomp_profile_is_set_to_docker_default_in_your_pod_definitions.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+check_title="Ensure that the seccomp profile is set to docker/default in your pod definitions (Manual)"
+check="$check_number  - $check_title"
+
+# TODO
+
+info "$check"

--- a/checks/policies/general_policies/the_default_namespace_should_not_be_used.sh
+++ b/checks/policies/general_policies/the_default_namespace_should_not_be_used.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+check_title="The default namespace should not be used (Manual)"
+check="$check_number  - $check_title"
+
+# TODO
+
+info "$check"

--- a/checks/policies/network_policies_and_cni/CNI_in_use_supports_NetworkPolicies.sh
+++ b/checks/policies/network_policies_and_cni/CNI_in_use_supports_NetworkPolicies.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+check_title="Ensure that the CNI in use supports Network Policies (Manual)"
+check="$check_number  - $check_title"
+
+# TODO
+
+info "$check"

--- a/checks/policies/network_policies_and_cni/all_namespaces_have_NetworkPolicies.sh
+++ b/checks/policies/network_policies_and_cni/all_namespaces_have_NetworkPolicies.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+check_title="Ensure that all Namespaces have Network Policies defined (Manual)"
+check="$check_number  - $check_title"
+
+# TODO
+
+info "$check"

--- a/checks/policies/pod_security_policies/minimize_admission_of_containers_wishing_to_share_the_host_IPC_namespace.sh
+++ b/checks/policies/pod_security_policies/minimize_admission_of_containers_wishing_to_share_the_host_IPC_namespace.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+check_title="Minimize the admission of containers wishing to share the host IPC namespace (Manual)"
+check="$check_number  - $check_title"
+
+# TODO
+
+info "$check"

--- a/checks/policies/pod_security_policies/minimize_admission_of_containers_wishing_to_share_the_host_network_namespace.sh
+++ b/checks/policies/pod_security_policies/minimize_admission_of_containers_wishing_to_share_the_host_network_namespace.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+check_title="Minimize the admission of containers wishing to share the host network namespace (Manual)"
+check="$check_number  - $check_title"
+
+# TODO
+
+info "$check"

--- a/checks/policies/pod_security_policies/minimize_admission_of_containers_wishing_to_share_the_host_process_ID_namespace.sh
+++ b/checks/policies/pod_security_policies/minimize_admission_of_containers_wishing_to_share_the_host_process_ID_namespace.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+check_title="Minimize the admission of containers wishing to share the host process ID namespace (Manual)"
+check="$check_number  - $check_title"
+
+# TODO
+
+info "$check"

--- a/checks/policies/pod_security_policies/minimize_admission_of_containers_with_added_capabilities.sh
+++ b/checks/policies/pod_security_policies/minimize_admission_of_containers_with_added_capabilities.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+check_title="Minimize the admission of containers with added capabilities (Manual)"
+check="$check_number  - $check_title"
+
+# TODO
+
+info "$check"

--- a/checks/policies/pod_security_policies/minimize_admission_of_containers_with_allowPrivilegeEscalation.sh
+++ b/checks/policies/pod_security_policies/minimize_admission_of_containers_with_allowPrivilegeEscalation.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+check_title="Minimize the admission of containers with allowPrivilegeEscalation (Manual)"
+check="$check_number  - $check_title"
+
+# TODO
+
+info "$check"

--- a/checks/policies/pod_security_policies/minimize_admission_of_containers_with_capabilities_assigned.sh
+++ b/checks/policies/pod_security_policies/minimize_admission_of_containers_with_capabilities_assigned.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+check_title="Minimize the admission of containers with capabilities assigned (Manual)"
+check="$check_number  - $check_title"
+
+# TODO
+
+info "$check"

--- a/checks/policies/pod_security_policies/minimize_admission_of_containers_with_the_NET_RAW_capability.sh
+++ b/checks/policies/pod_security_policies/minimize_admission_of_containers_with_the_NET_RAW_capability.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+check_title="Minimize the admission of containers with the NET_RAW capability (Manual)"
+check="$check_number  - $check_title"
+
+# TODO
+
+info "$check"

--- a/checks/policies/pod_security_policies/minimize_admission_of_privileged_containers.sh
+++ b/checks/policies/pod_security_policies/minimize_admission_of_privileged_containers.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+check_title="Minimize the admission of privileged containers (Manual)"
+check="$check_number  - $check_title"
+
+# TODO
+
+info "$check"

--- a/checks/policies/pod_security_policies/minimize_admission_of_root_containers.sh
+++ b/checks/policies/pod_security_policies/minimize_admission_of_root_containers.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+check_title="Minimize the admission of root containers (Manual)"
+check="$check_number  - $check_title"
+
+# TODO
+
+info "$check"

--- a/checks/policies/rbac_and_service_accounts/cluster-admin_role_is_only_used_where_required.sh
+++ b/checks/policies/rbac_and_service_accounts/cluster-admin_role_is_only_used_where_required.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+check_title="Ensure that the cluster-admin role is only used where required (Manual)"
+check="$check_number  - $check_title"
+
+# Make the loop separator be a new-line in POSIX compliant fashion
+set -f; IFS=$'
+'
+
+cluster_admins=$(kubectl get clusterrolebindings -o=custom-columns=NAME:.metadata.name,ROLE:.roleRef.name,SUBJECT:.subjects[*].name)
+info "$check"
+for admin in $cluster_admins; do
+ 	info "     * $admin"
+done

--- a/checks/policies/rbac_and_service_accounts/default_service_accounts_are_not_actively_used.sh
+++ b/checks/policies/rbac_and_service_accounts/default_service_accounts_are_not_actively_used.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+check_title="Ensure that default service accounts are not actively used (Manual)"
+check="$check_number  - $check_title"
+
+# TODO
+
+info "$check"

--- a/checks/policies/rbac_and_service_accounts/minimize_access_to_create_pods.sh
+++ b/checks/policies/rbac_and_service_accounts/minimize_access_to_create_pods.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+check_title="Minimize access to create pods (Manual)"
+check="$check_number  - $check_title"
+
+# TODO
+
+info "$check"

--- a/checks/policies/rbac_and_service_accounts/minimize_access_to_secrets.sh
+++ b/checks/policies/rbac_and_service_accounts/minimize_access_to_secrets.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+check_title="Minimize access to secrets (Manual)"
+check="$check_number  - $check_title"
+
+# Make the loop separator be a new-line in POSIX compliant fashion
+set -f; IFS=$'
+'
+
+policies=$(kubectl get psp)
+info "$check"
+for policy in $policies; do
+	  info "     * $policy"
+done

--- a/checks/policies/rbac_and_service_accounts/minimize_wildcard_use_in_Roles_and_ClusterRoles.sh
+++ b/checks/policies/rbac_and_service_accounts/minimize_wildcard_use_in_Roles_and_ClusterRoles.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+check_title="Minimize wildcard use in Roles and ClusterRoles (Manual)"
+check="$check_number  - $check_title"
+
+# TODO
+
+info "$check"

--- a/checks/policies/rbac_and_service_accounts/service_account_tokens_are_only_mounted_where_necessary.sh
+++ b/checks/policies/rbac_and_service_accounts/service_account_tokens_are_only_mounted_where_necessary.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+check_title="Ensure that Service Account Tokens are only mounted where necessary (Manual)"
+check="$check_number  - $check_title"
+
+# TODO
+
+info "$check"

--- a/checks/policies/secrets_management/consider_external_secret_storage.sh
+++ b/checks/policies/secrets_management/consider_external_secret_storage.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+check_title="Consider external secret storage (Manual)"
+check="$check_number  - $check_title"
+
+# TODO
+
+info "$check"

--- a/checks/policies/secrets_management/prefer_using_secrets_as_files_over_environment_variables.sh
+++ b/checks/policies/secrets_management/prefer_using_secrets_as_files_over_environment_variables.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+check_title="Prefer using secrets as files over secrets as environment variables (Manual)"
+check="$check_number  - $check_title"
+
+# TODO
+
+info "$check"

--- a/checks/worker_nodes/configuration_files/certificate_authorities_file_permissions.sh
+++ b/checks/worker_nodes/configuration_files/certificate_authorities_file_permissions.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+check_title="Ensure that the certificate authorities file permissions are set to 644 or more restrictive (Manual)"
+check="$check_number  - $check_title"
+
+if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
+  file=$(get_argument_value "$CIS_KUBELET_CMD" '--client-ca-file')
+  if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
+    pass "$check"
+    pass "       * client-ca-file: $file"
+  else
+    warn "$check"
+    warn "     * Wrong permissions for $file"
+  fi
+else
+  info "$check"
+  info "     * --client-ca-file not set"
+fi

--- a/checks/worker_nodes/configuration_files/client_certificate_authorities_file_ownership.sh
+++ b/checks/worker_nodes/configuration_files/client_certificate_authorities_file_ownership.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+check_title="Ensure that the client certificate authorities file ownership is set to root:root (Manual)"
+check="$check_number  - $check_title"
+
+if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
+  file=$(get_argument_value "$CIS_KUBELET_CMD" '--client-ca-file')
+  if [ "$(stat -c %u%g $file)" -eq 00 ]; then
+    pass "$check"
+    pass "       * client-ca-file: $file"
+  else
+    warn "$check"
+    warn "     * Wrong ownership for $file"
+  fi
+else
+  info "$check"
+  info "     * --client-ca-file not set"
+fi

--- a/checks/worker_nodes/configuration_files/kubelet_conf_file_ownership.sh
+++ b/checks/worker_nodes/configuration_files/kubelet_conf_file_ownership.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+check_title="Ensure that the kubelet.conf file ownership is set to root:root (Manual)"
+check="$check_number  - $check_title"
+
+if [ -f "/var/lib/kube-proxy/kubeconfig" ]; then
+    # kops
+    file="/var/lib/kube-proxy/kubeconfig"
+else
+    file="/etc/kubernetes/proxy"
+fi
+
+if [ -f "$file" ]; then
+  if [ "$(stat -c %u%g $file)" -eq 00 ]; then
+    pass "$check"
+  else
+    warn "$check"
+    warn "     * Wrong ownership for $file"
+  fi
+else
+  info "$check"
+fi

--- a/checks/worker_nodes/configuration_files/kubelet_conf_file_permissions.sh
+++ b/checks/worker_nodes/configuration_files/kubelet_conf_file_permissions.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+check_title="Ensure that the kubelet.conf file permissions are set to 644 or more restrictive (Automated)"
+check="$check_number  - $check_title"
+
+if [ -f "/var/lib/kube-proxy/kubeconfig" ]; then
+    # kops
+    file="/var/lib/kube-proxy/kubeconfig"
+else
+    file="/etc/kubernetes/proxy"
+fi
+
+if [ -f "$file" ]; then
+  if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
+    pass "$check"
+  else
+    warn "$check"
+    warn "     * Wrong permissions for $file"
+  fi
+else
+  info "$check"
+  info "     * File not found"
+fi

--- a/checks/worker_nodes/configuration_files/kubelet_configuration_file_ownership.sh
+++ b/checks/worker_nodes/configuration_files/kubelet_configuration_file_ownership.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+check_title="Ensure that the kubelet configuration file ownership is set to root:root (Automated)"
+check="$check_number  - $check_title"
+
+if check_argument "$CIS_KUBELET_CMD" '--config' >/dev/null 2>&1; then
+  file=$(get_argument_value "$CIS_KUBELET_CMD" '--config')
+  if [ "$(stat -c %u%g $file)" -eq 00 ]; then
+    pass "$check"
+    pass "       * kubelet configuration file: $file"
+  else
+    warn "$check"
+    warn "     * Wrong ownership for $file"
+  fi
+else
+  info "$check"
+  info "     * kubelet configuration file not set"
+fi

--- a/checks/worker_nodes/configuration_files/kubelet_configuration_file_permissions.sh
+++ b/checks/worker_nodes/configuration_files/kubelet_configuration_file_permissions.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+check_title="Ensure that the kubelet configuration file has permissions set to 644 or more restrictive (Automated)"
+check="$check_number  - $check_title"
+
+if check_argument "$CIS_KUBELET_CMD" '--config' >/dev/null 2>&1; then
+  file=$(get_argument_value "$CIS_KUBELET_CMD" '--config')
+  if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
+    pass "$check"
+    pass "       * kubelet configuration file: $file"
+  else
+    warn "$check"
+    warn "     * Wrong permissions for $file"
+  fi
+else
+  info "$check"
+  info "     * kubelet configuration file not set"
+fi

--- a/checks/worker_nodes/configuration_files/kubelet_service_file_ownership.sh
+++ b/checks/worker_nodes/configuration_files/kubelet_service_file_ownership.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+check_title="Ensure that the kubelet service file ownership is set to root:root (Automated)"
+check="$check_number  - $check_title"
+
+file="/etc/systemd/system/kubelet.service.d/10-kubeadm.conf"
+
+if [ -f "$file" ]; then
+  if [ "$(stat -c %u%g $file)" -eq 00 ]; then
+    pass "$check"
+  else
+    warn "$check"
+    warn "     * Wrong ownership for $file"
+  fi
+else
+  info "$check"
+fi

--- a/checks/worker_nodes/configuration_files/kubelet_service_file_permissions.sh
+++ b/checks/worker_nodes/configuration_files/kubelet_service_file_permissions.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+check_title="Ensure that the kubelet service file permissions are set to 644 or more restrictive (Automated)"
+check="$check_number  - $check_title"
+
+file="/etc/systemd/system/kubelet.service.d/10-kubeadm.conf"
+
+if [ -f "$file" ]; then
+  if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
+    pass "$check"
+  else
+    warn "$check"
+    warn "     * Wrong permissions for $file"
+  fi
+else
+  info "$check"
+  info "     * The kubelet service file not found"
+fi

--- a/checks/worker_nodes/configuration_files/proxy_kubeconfig_file_ownership.sh
+++ b/checks/worker_nodes/configuration_files/proxy_kubeconfig_file_ownership.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+check_title="Ensure that the proxy kubeconfig file ownership is set to root:root (Manual)"
+check="$check_number  - $check_title"
+
+file=""
+if check_argument "$CIS_PROXY_CMD" '--kubeconfig' >/dev/null 2>&1; then
+    file=$(get_argument_value "$CIS_PROXY_CMD" '--kubeconfig'|cut -d " " -f 1)
+fi
+
+if [ -f "$file" ]; then
+  if [ "$(stat -c %u%g $file)" -eq 00 ]; then
+    pass "$check"
+  else
+    warn "$check"
+    warn "     * Wrong ownership for $file"
+  fi
+else
+  info "$check"
+  info "     * kubeconfig file not found"
+fi

--- a/checks/worker_nodes/configuration_files/proxy_kubeconfig_file_permissions.sh
+++ b/checks/worker_nodes/configuration_files/proxy_kubeconfig_file_permissions.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+check_title="Ensure that the proxy kubeconfig file permissions are set to 644 or more restrictive (Manual)"
+check="$check_number  - $check_title"
+
+file=""
+if check_argument "$CIS_PROXY_CMD" '--kubeconfig' >/dev/null 2>&1; then
+    file=$(get_argument_value "$CIS_PROXY_CMD" '--kubeconfig'|cut -d " " -f 1)
+fi
+
+if [ -f "$file" ]; then
+  if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
+    pass "$check"
+  else
+    warn "$check"
+    warn "     * Wrong permissions for $file"
+  fi
+else
+  info "$check"
+  info "     * kubeconfig file not found"
+fi

--- a/checks/worker_nodes/kubelet/RotateKubeletServerCertificate_is_set_to_true.sh
+++ b/checks/worker_nodes/kubelet/RotateKubeletServerCertificate_is_set_to_true.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+check_title="Ensure that the RotateKubeletServerCertificate argument is set to true (Manual)"
+check="$check_number  - $check_title"
+
+file="/etc/systemd/system/kubelet.service.d/10-kubeadm.conf"
+
+found=$(sed -rn '/--feature-gates=RotateKubeletServerCertificate=true/p' $file)
+if [ -z "$found" ]; then
+    warn "$check"
+else
+    pass "$check"
+fi

--- a/checks/worker_nodes/kubelet/anonymous-auth_is_set_to_false.sh
+++ b/checks/worker_nodes/kubelet/anonymous-auth_is_set_to_false.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+check_title="Ensure that the --anonymous-auth argument is set to false (Automated)"
+check="$check_number  - $check_title"
+
+if check_argument "$CIS_KUBELET_CMD" '--anonymous-auth=false' >/dev/null 2>&1; then
+    pass "$check"
+else
+    warn "$check"
+fi

--- a/checks/worker_nodes/kubelet/authorization-mode_is_not_set_to_AlwaysAllow.sh
+++ b/checks/worker_nodes/kubelet/authorization-mode_is_not_set_to_AlwaysAllow.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+check_title="Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)"
+check="$check_number  - $check_title"
+
+if check_argument "$CIS_KUBELET_CMD" '--authorization-mode=AlwaysAllow' >/dev/null 2>&1; then
+    warn "$check"
+else
+    pass "$check"
+fi

--- a/checks/worker_nodes/kubelet/client-ca-file_is_set.sh
+++ b/checks/worker_nodes/kubelet/client-ca-file_is_set.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+check_title="Ensure that the --client-ca-file argument is set as appropriate (Automated)"
+check="$check_number  - $check_title"
+
+if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
+    cafile=$(get_argument_value "$CIS_KUBELET_CMD" '--client-ca-file')
+    pass "$check"
+    pass "       * client-ca-file: $cafile"
+else
+    warn "$check"
+fi

--- a/checks/worker_nodes/kubelet/event-qps_is_set_to_0_or_appropriate.sh
+++ b/checks/worker_nodes/kubelet/event-qps_is_set_to_0_or_appropriate.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+check_title="Ensure that the --event-qps argument is set to 0 or a level which ensures appropriate event capture (Manual)"
+check="$check_number  - $check_title"
+
+# todo check if its right
+
+if check_argument "$CIS_KUBELET_CMD" '--event-qps' >/dev/null 2>&1; then
+    event=$(get_argument_value "$CIS_KUBELET_CMD" '--event-qps' | cut -d " " -f 1)
+    if [ $event = "0" ]; then
+        pass "$check"
+    else
+        warn "$check"
+        warn "        * event-qps: $event"
+    fi
+else
+    warn "$check"
+fi

--- a/checks/worker_nodes/kubelet/hostname-override_is_not_set.sh
+++ b/checks/worker_nodes/kubelet/hostname-override_is_not_set.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+check_title="Ensure that the --hostname-override argument is not set (Manual)"
+check="$check_number  - $check_title"
+
+if check_argument "$CIS_KUBELET_CMD" '--hostname-override' >/dev/null 2>&1; then
+    warn "$check"
+else
+    pass "$check"
+fi

--- a/checks/worker_nodes/kubelet/kubelet_only_makes_use_of_strong_cryptographic_ciphers.sh
+++ b/checks/worker_nodes/kubelet/kubelet_only_makes_use_of_strong_cryptographic_ciphers.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+check_title="Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Manual)"
+check="$check_number  - $check_title"
+
+# todo check if its right
+
+if check_argument "$CIS_KUBELET_CMD" '--cadvisor-port' >/dev/null 2>&1; then
+    port=$(get_argument_value "$CIS_KUBELET_CMD" '--cadvisor-port' | cut -d " " -f 1)
+    if [ $port = "0" ]; then
+        pass "$check"
+    else
+        warn "$check"
+        warn "        * cadvisor-port: $port"
+    fi
+else
+    warn "$check"
+fi

--- a/checks/worker_nodes/kubelet/make-iptables-util-chains_is_set_to_true.sh
+++ b/checks/worker_nodes/kubelet/make-iptables-util-chains_is_set_to_true.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+check_title="Ensure that the --make-iptables-util-chains argument is set to true (Automated)"
+check="$check_number  - $check_title"
+
+if check_argument "$CIS_KUBELET_CMD" '--make-iptables-util-chains=true' >/dev/null 2>&1; then
+    pass "$check"
+else
+    warn "$check"
+fi

--- a/checks/worker_nodes/kubelet/protect-kernel-defaults_is_set_to_true.sh
+++ b/checks/worker_nodes/kubelet/protect-kernel-defaults_is_set_to_true.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+check_title="Ensure that the --protect-kernel-defaults argument is set to true (Automated)"
+check="$check_number  - $check_title"
+
+if check_argument "$CIS_KUBELET_CMD" '--protect-kernel-defaults=true' >/dev/null 2>&1; then
+    pass "$check"
+else
+    warn "$check"
+fi

--- a/checks/worker_nodes/kubelet/read-only-port_is_set_to_0.sh
+++ b/checks/worker_nodes/kubelet/read-only-port_is_set_to_0.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+check_title="Ensure that the --read-only-port argument is set to 0 (Manual)"
+check="$check_number  - $check_title"
+
+if check_argument "$CIS_KUBELET_CMD" '--read-only-port' >/dev/null 2>&1; then
+    port=$(get_argument_value "$CIS_KUBELET_CMD" '--read-only-port' | cut -d " " -f 1)
+    if [ $port = "0" ]; then
+        pass "$check"
+    else
+        warn "$check"
+        warn "       * read-only-port: $port"
+    fi
+else
+    warn "$check"
+fi

--- a/checks/worker_nodes/kubelet/rotate-certificates_is_not_set_to_false.sh
+++ b/checks/worker_nodes/kubelet/rotate-certificates_is_not_set_to_false.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+check_title="Ensure that the --rotate-certificates argument is not set to false (Manual)"
+check="$check_number  - $check_title"
+
+if check_argument "$CIS_KUBELET_CMD" '--event-qps' >/dev/null 2>&1; then
+    event=$(get_argument_value "$CIS_KUBELET_CMD" '--event-qps' | cut -d " " -f 1)
+    if [ $event = "0" ]; then
+        pass "$check"
+    else
+        warn "$check"
+        warn "        * event-qps: $event"
+    fi
+else
+    warn "$check"
+fi

--- a/checks/worker_nodes/kubelet/streaming-connection-idle-timeout_is_not_set_to_0.sh
+++ b/checks/worker_nodes/kubelet/streaming-connection-idle-timeout_is_not_set_to_0.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+check_title="Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Manual)"
+check="$check_number  - $check_title"
+
+if check_argument "$CIS_KUBELET_CMD" '--streaming-connection-idle-timeout=0' >/dev/null 2>&1; then
+    timeout=$(get_argument_value "$CIS_KUBELET_CMD" '--streaming-connection-idle-timeout')
+    warn "$check"
+    warn "       * streaming-connection-idle-timeout: $timeout"
+else
+    pass "$check"
+fi

--- a/checks/worker_nodes/kubelet/tls-cert-file_and_tls-private-key-file_are_set.sh
+++ b/checks/worker_nodes/kubelet/tls-cert-file_and_tls-private-key-file_are_set.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+check_title="Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Manual)"
+check="$check_number  - $check_title"
+
+if check_argument "$CIS_KUBELET_CMD" '--tls-cert-file' >/dev/null 2>&1; then
+    if check_argument "$CIS_KUBELET_CMD" '--tls-private-key-file' >/dev/null 2>&1; then
+        cfile=$(get_argument_value "$CIS_KUBELET_CMD" '--tls-cert-file')
+        kfile=$(get_argument_value "$CIS_KUBELET_CMD" '--tls-private-key-file')
+        pass "$check"
+        pass "        * tls-cert-file: $cfile"
+        pass "        * tls-private-key-file: $kfile"
+    else
+      warn "$check"
+    fi
+else
+    warn "$check"
+fi

--- a/helper.sh
+++ b/helper.sh
@@ -1,19 +1,5 @@
 #!/bin/sh
 
-if [ -n "$nocolor" ] && [ "$nocolor" = "nocolor" ]; then
-  bldred=''
-  bldgrn=''
-  bldblu=''
-  bldylw=''
-  txtrst=''
-else
-  bldred='\033[1;31m'
-  bldgrn='\033[1;32m'
-  bldblu='\033[1;34m'
-  bldylw='\033[1;33m'
-  txtrst='\033[0m'
-fi
-
 info () {
   printf "%b\n" "${bldblu}[INFO]${txtrst} $1"
 }
@@ -26,10 +12,6 @@ warn () {
   printf "%b\n" "${bldred}[WARN]${txtrst} $1"
 }
 
-yell () {
-  printf "%b\n" "${bldylw}$1${txtrst}\n"
-}
-
 yell "# ------------------------------------------------------------------------------
 # Kubernetes CIS benchmark
 #
@@ -40,43 +22,4 @@ yell "# ------------------------------------------------------------------------
 # security concerns slow down your CI/CD processes.
 # ------------------------------------------------------------------------------"
 
-#get a process command line from /proc
-get_command_line_args() {
-    PROC="$1"
-    len=${#PROC}
-    if [ $len -gt 15 ]; then
-		ps aux|grep  "$CMD "|grep -v "grep" |sed "s/.*$CMD \(.*\)/\1/g"
-    else
-        for PID in $(pgrep -n "$PROC")
-        do
-            tr "\0" " " < /proc/"$PID"/cmdline
-        done
-    fi
-}
-
-#get an argument value from command line
-get_argument_value() {
-    CMD="$1"
-    OPTION="$2"
-
-    get_command_line_args "$CMD" |
-    sed \
-        -e 's/\-\-/\n--/g' \
-        |
-    grep "^${OPTION}" |
-    sed \
-        -e "s/^${OPTION}=//g"
-}
-
-#check whether an argument exist in command line
-check_argument() {
-    CMD="$1"
-    OPTION="$2"
-
-    get_command_line_args "$CMD" |
-    sed \
-        -e 's/\-\-/\n--/g' \
-        |
-    grep "^${OPTION}" 
-}
 

--- a/helper1_4_1.sh
+++ b/helper1_4_1.sh
@@ -1,23 +1,5 @@
 #!/bin/sh
 
-if [ -n "$nocolor" ] && [ "$nocolor" = "nocolor" ]; then
-  bldred=''
-  bldgrn=''
-  bldblu=''
-  bldylw=''
-  bldcyn=''
-  bldgry=''
-  txtrst=''
-else
-  bldred='\033[1;31m'
-  bldgrn='\033[1;32m'
-  bldblu='\033[1;34m'
-  bldylw='\033[1;33m'
-  bldcyn='\033[1;36m'
-  bldgry='\033[1;37m'
-  txtrst='\033[0m'
-fi
-
 notScored="1.1.1, 1.1.12, 1.1.13, 1.1.31, 1.4.9, 1.4.10, 1.5.7, 1.6.1, 1.6.2, 1.6.3, 1.6.4, 1.6.5, 1.6.6, 1.6.7, 1.6.8,
 1.7.1, 1.7.6, 1.7.7, 2.1.11, 2.1.14"
 level2="1.3.6, 1.5.7, 1.6.1, 1.6.4, 1.6.5, 1.6.6, 1.6.7, 1.6.8,
@@ -90,10 +72,6 @@ warn () {
 
 }
 
-yell () {
-  printf "%b\n" "${bldylw}$1${txtrst}\n"
-}
-
 yell "# ------------------------------------------------------------------------------
 # Kubernetes CIS benchmark
 #
@@ -103,44 +81,3 @@ yell "# ------------------------------------------------------------------------
 # solution that automatically adapts to protect running containers. Don’t let
 # security concerns slow down your CI/CD processes.
 # ------------------------------------------------------------------------------"
-
-#get a process command line from /proc
-get_command_line_args() {
-    PROC="$1"
-    len=${#PROC}
-    if [ $len -gt 15 ]; then
-		ps aux|grep  "$CMD "|grep -v "grep" |sed "s/.*$CMD \(.*\)/\1/g"
-    else
-        for PID in $(pgrep -n "$PROC")
-        do
-            tr "\0" " " < /proc/"$PID"/cmdline
-        done
-    fi
-}
-
-#get an argument value from command line
-get_argument_value() {
-    CMD="$1"
-    OPTION="$2"
-
-    get_command_line_args "$CMD" |
-    sed \
-        -e 's/\-\-/\n--/g' \
-        |
-    grep "^${OPTION}" |
-    sed \
-        -e "s/^${OPTION}=//g"
-}
-
-#check whether an argument exist in command line
-check_argument() {
-    CMD="$1"
-    OPTION="$2"
-
-    get_command_line_args "$CMD" |
-    sed \
-        -e 's/\-\-/\n--/g' \
-        |
-    grep "^${OPTION}"
-}
-

--- a/helper1_5_1.sh
+++ b/helper1_5_1.sh
@@ -1,23 +1,5 @@
 #!/bin/sh
 
-if [ -n "$nocolor" ] && [ "$nocolor" = "nocolor" ]; then
-  bldred=''
-  bldgrn=''
-  bldblu=''
-  bldylw=''
-  bldcyn=''
-  bldgry=''
-  txtrst=''
-else
-  bldred='\033[1;31m'
-  bldgrn='\033[1;32m'
-  bldblu='\033[1;34m'
-  bldylw='\033[1;33m'
-  bldcyn='\033[1;36m'
-  bldgry='\033[1;37m'
-  txtrst='\033[0m'
-fi
-
 level2="1.3.6, 2.7, 3.1.1, 3.2.2, 4.2.9, 5.2.9, 5.3.2, 5.4.2, 5.5.1, 5.7.2, 5.7.3, 5.7.4"
 
 info () {
@@ -87,10 +69,6 @@ warn () {
 
 }
 
-yell () {
-  printf "%b\n" "${bldylw}$1${txtrst}\n"
-}
-
 yell "# ------------------------------------------------------------------------------
 # Kubernetes CIS benchmark
 #
@@ -100,44 +78,3 @@ yell "# ------------------------------------------------------------------------
 # solution that automatically adapts to protect running containers. Don’t let
 # security concerns slow down your CI/CD processes.
 # ------------------------------------------------------------------------------"
-
-#get a process command line from /proc
-get_command_line_args() {
-    PROC="$1"
-    len=${#PROC}
-    if [ $len -gt 15 ]; then
-		ps aux|grep  "$CMD "|grep -v "grep" |sed "s/.*$CMD \(.*\)/\1/g"
-    else
-        for PID in $(pgrep -n "$PROC")
-        do
-            tr "\0" " " < /proc/"$PID"/cmdline
-        done
-    fi
-}
-
-#get an argument value from command line
-get_argument_value() {
-    CMD="$1"
-    OPTION="$2"
-
-    get_command_line_args "$CMD" |
-    sed \
-        -e 's/\-\-/\n--/g' \
-        |
-    grep "^${OPTION}" |
-    sed \
-        -e "s/^${OPTION}=//g"
-}
-
-#check whether an argument exist in command line
-check_argument() {
-    CMD="$1"
-    OPTION="$2"
-
-    get_command_line_args "$CMD" |
-    sed \
-        -e 's/\-\-/\n--/g' \
-        |
-    grep "^${OPTION}"
-}
-

--- a/helper1_6_0.sh
+++ b/helper1_6_0.sh
@@ -1,23 +1,5 @@
 #!/bin/sh
 
-if [ -n "$nocolor" ] && [ "$nocolor" = "nocolor" ]; then
-  bldred=''
-  bldgrn=''
-  bldblu=''
-  bldylw=''
-  bldcyn=''
-  bldgry=''
-  txtrst=''
-else
-  bldred='\033[1;31m'
-  bldgrn='\033[1;32m'
-  bldblu='\033[1;34m'
-  bldylw='\033[1;33m'
-  bldcyn='\033[1;36m'
-  bldgry='\033[1;37m'
-  txtrst='\033[0m'
-fi
-
 level2="1.3.6, 2.7, 3.1.1, 3.2.2, 4.2.9, 5.2.9, 5.3.2, 5.4.2, 5.5.1, 5.7.2, 5.7.3, 5.7.4"
 not_scored="1.1.9, 1.1.10, 1.1.20, 1.1.21, 1.2.1, 1.2.10, 1.2.12, 1.2.13, 1.2.33, 1.2.34, 1.2.35, 1.3.1, 2.7, 3.1.1, 3.2.2, 4,2.8, 4.2.9, 4.2.13, 5.1.1, 5.1.2, 5.1.3, 5.1.4, 5.1.6, 5.2.1, 5.2.6, 5.2.7, 5.2.8, 5.2.9, 5.3.1, 5.4.1, 5.4.2, 5.5.1, 5.7.1, 5.7.2, 5.7.3"
 assessment_manual="1.1.9, 1.1.10, 1.1.20, 1.1.21, 1.2.1, 1.2.10, 1.2.12, 1.2.13, 1.2.33, 1.2.34, 1.2.35, 1.3.1, 2.7, 3.1.1, 3.2.1, 3.2.2, 4.1.3, 4.1.4, 4.1.6, 4.1.7, 4.1.8, 4.2.4, 4.2.5, 4.2.8, 4.2.9, 4.2.10, 4.2.11, 4.2.12, 4.2.13, 5.1.1, 5.1.2, 5.1.3, 5.1.4, 5.1.5, 5.1.6, 5.2.1, 5.2.2, 5.2.3, 5.2.4, 5.2.5, 5.2.6, 5.2.7, 5.2.8, 5.2.9, 5.3.1, 5.3.2, 5.4.1, 5.4.2, 5.5.1, 5.7.1, 5.7.2, 5.7.3, 5.7.4"
@@ -107,10 +89,6 @@ warn () {
 
 }
 
-yell () {
-  printf "%b\n" "${bldylw}$1${txtrst}\n"
-}
-
 yell "# ------------------------------------------------------------------------------
 # Kubernetes CIS benchmark
 #
@@ -120,44 +98,3 @@ yell "# ------------------------------------------------------------------------
 # solution that automatically adapts to protect running containers. Don’t let
 # security concerns slow down your CI/CD processes.
 # ------------------------------------------------------------------------------"
-
-#get a process command line from /proc
-get_command_line_args() {
-    PROC="$1"
-    len=${#PROC}
-    if [ $len -gt 15 ]; then
-		ps aux|grep  "$CMD "|grep -v "grep" |sed "s/.*$CMD \(.*\)/\1/g"
-    else
-        for PID in $(pgrep -n "$PROC")
-        do
-            tr "\0" " " < /proc/"$PID"/cmdline
-        done
-    fi
-}
-
-#get an argument value from command line
-get_argument_value() {
-    CMD="$1"
-    OPTION="$2"
-
-    get_command_line_args "$CMD" |
-    sed \
-        -e 's/\-\-/\n--/g' \
-        |
-    grep "^${OPTION}" |
-    sed \
-        -e "s/^${OPTION}=//g"
-}
-
-#check whether an argument exist in command line
-check_argument() {
-    CMD="$1"
-    OPTION="$2"
-
-    get_command_line_args "$CMD" |
-    sed \
-        -e 's/\-\-/\n--/g' \
-        |
-    grep "^${OPTION}"
-}
-

--- a/helper_common.sh
+++ b/helper_common.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+
+# common utility for all versions. can be overriten in specific files 
+
+if [ -n "$nocolor" ] && [ "$nocolor" = "nocolor" ]; then
+  bldred=''
+  bldgrn=''
+  bldblu=''
+  bldylw=''
+  bldcyn=''
+  bldgry=''
+  txtrst=''
+else
+  bldred='\033[1;31m'
+  bldgrn='\033[1;32m'
+  bldblu='\033[1;34m'
+  bldylw='\033[1;33m'
+  bldcyn='\033[1;36m'
+  bldgry='\033[1;37m'
+  txtrst='\033[0m'
+fi
+
+# get a process command line from /proc
+get_command_line_args() {
+    PROC="$1"
+    len=${#PROC}
+    if [ $len -gt 15 ]; then
+		ps aux|grep  "$CMD "|grep -v "grep" |sed "s/.*$CMD \(.*\)/\1/g"
+    else
+        for PID in $(pgrep -n "$PROC")
+        do
+            tr "\0" " " < /proc/"$PID"/cmdline
+        done
+    fi
+}
+
+# get an argument value from command line
+get_argument_value() {
+    CMD="$1"
+    OPTION="$2"
+
+    get_command_line_args "$CMD" |
+    sed \
+        -e 's/\-\-/\n--/g' \
+        |
+    grep "^${OPTION}" |
+    sed \
+        -e "s/^${OPTION}=//g"
+}
+
+# check whether an argument exist in command line
+check_argument() {
+    CMD="$1"
+    OPTION="$2"
+
+    get_command_line_args "$CMD" |
+    sed \
+        -e 's/\-\-/\n--/g' \
+        |
+    grep "^${OPTION}"
+}
+
+yell () {
+  printf "%b\n" "${bldylw}$1${txtrst}\n"
+}

--- a/helper_gke.sh
+++ b/helper_gke.sh
@@ -1,23 +1,5 @@
 #!/bin/sh
 
-if [ -n "$nocolor" ] && [ "$nocolor" = "nocolor" ]; then
-  bldred=''
-  bldgrn=''
-  bldblu=''
-  bldylw=''
-  bldcyn=''
-  bldgry=''
-  txtrst=''
-else
-  bldred='\033[1;31m'
-  bldgrn='\033[1;32m'
-  bldblu='\033[1;34m'
-  bldylw='\033[1;33m'
-  bldcyn='\033[1;36m'
-  bldgry='\033[1;37m'
-  txtrst='\033[0m'
-fi
-
 level2="1.3.6, 2.7, 3.1.1, 3.2.2, 4.2.9, 5.2.6, 5.2.9, 5.3.2, 5.4.2, 5.6.2, 5.6.3, 5.6.4,
 6.1.4, 6.2.1, 6.4.2, 6.5.1, 6.5.7, 6.6.1, 6.6.4, 6.6.8, 6.7.2, 6.8.3, 6.10.4, 6.10.5"
 
@@ -88,10 +70,6 @@ warn () {
 
 }
 
-yell () {
-  printf "%b\n" "${bldylw}$1${txtrst}\n"
-}
-
 yell "# ------------------------------------------------------------------------------
 # Kubernetes CIS benchmark
 #
@@ -101,20 +79,6 @@ yell "# ------------------------------------------------------------------------
 # solution that automatically adapts to protect running containers. Don’t let
 # security concerns slow down your CI/CD processes.
 # ------------------------------------------------------------------------------"
-
-#get a process command line from /proc
-get_command_line_args() {
-    PROC="$1"
-    len=${#PROC}
-    if [ $len -gt 15 ]; then
-		ps aux|grep  "$CMD "|grep -v "grep" |sed "s/.*$CMD \(.*\)/\1/g"
-    else
-        for PID in $(pgrep -n "$PROC")
-        do
-            tr "\0" " " < /proc/"$PID"/cmdline
-        done
-    fi
-}
 
 #get an argument value from command line
 get_argument_value() {
@@ -129,16 +93,3 @@ get_argument_value() {
     sed \
         -e "s/^${OPTION}[= ]//g"
 }
-
-#check whether an argument exist in command line
-check_argument() {
-    CMD="$1"
-    OPTION="$2"
-
-    get_command_line_args "$CMD" |
-    sed \
-        -e 's/\-\-/\n--/g' \
-        |
-    grep "^${OPTION}"
-}
-

--- a/master.sh
+++ b/master.sh
@@ -11,7 +11,7 @@ usage () {
   usage: ./master.sh [-b] VERSION
 
   -b           optional  Do not print colors
-  VERSION      required  CIS benchmark version, for example: "gke", "1.6.0", "1.5.1", "1.4.1", "1.2.0", "1.0.0"
+  VERSION      required  CIS benchmark version, for example: "gke", "1.6.0-refactor", "1.6.0", "1.5.1", "1.4.1", "1.2.0", "1.0.0"
 EOF
 }
 
@@ -19,7 +19,7 @@ while [ "$#" -ge 0 ]
 do
   case $1 in
     -b) nocolor="nocolor"; shift;;
-    1.0.0|1.2.0|1.4.1|1.5.1|1.6.0|gke) ver=$1; break 2;;
+    1.0.0|1.2.0|1.4.1|1.5.1|1.6.0|1.6.0-refactor|gke) ver=$1; break 2;;
     *) usage; exit 1;;
   esac
 done
@@ -30,11 +30,16 @@ CIS_SCHEDULER_CMD=${CIS_SCHEDULER_CMD:-kube-scheduler}
 CIS_ETCD_CMD=${CIS_ETCD_CMD:-etcd}
 CIS_PROXY_CMD=${CIS_PROXY_CMD:-kube-proxy}
 
+. ./helper_common.sh
+
 case $ver in
   gke)
     . ./helper_gke.sh
     ;;
   1.6.0)
+    . ./helper1_6_0.sh
+    ;;
+  1.6.0-refactor)
     . ./helper1_6_0.sh
     ;;
   1.5.1)

--- a/worker.sh
+++ b/worker.sh
@@ -11,7 +11,7 @@ usage () {
   usage: ./worker.sh [-b] VERSION
 
   -b           optional  Do not print colors
-  VERSION      required  CIS benchmark version, for example: "gke", "1.6.0", "1.5.1", "1.4.1", "1.2.0", "1.0.0"
+  VERSION      required  CIS benchmark version, for example: "gke", "1.6.0-refactor", "1.6.0", "1.5.1", "1.4.1", "1.2.0", "1.0.0"
 EOF
 }
 
@@ -19,19 +19,25 @@ while [ "$#" -ge 0 ]
 do
   case $1 in
     -b) nocolor="nocolor"; shift;;
-    1.0.0|1.2.0|1.4.1|1.5.1|1.6.0|gke) ver=$1; break 2;;
+    1.0.0|1.2.0|1.4.1|1.5.1|1.6.0|1.6.0-refactor|gke) ver=$1; break 2;;
     *) usage; exit 1;;
   esac
 done
 
 CIS_KUBELET_CMD=${CIS_KUBELET_CMD:-kubelet}
 CIS_PROXY_CMD=${CIS_PROXY_CMD:-kube-proxy}
+
 # Load dependencies
+. ./helper_common.sh
+
 case $ver in
   gke)
     . ./helper_gke.sh
     ;;
   1.6.0)
+    . ./helper1_6_0.sh
+    ;;
+  1.6.0-refactor)
     . ./helper1_6_0.sh
     ;;
   1.5.1)


### PR DESCRIPTION
This PR brings the following changes:

- Checks from Version 1.6.0 of the scripts are refactored into separate files, using the `checks/` folder
- Helpers are refactored in order to remove duplicated code
- Version 1.6.0-refactor is added as a temporary refactored version of the 1.6.0 version using the `checks` folder

This changes are created in order to build a foundation for next version, 1.7.0, with less repeated code and more maintainability